### PR TITLE
feat: Implementa a classe AttributeMerger

### DIFF
--- a/app/components/ink_components/attribute_merger.rb
+++ b/app/components/ink_components/attribute_merger.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module InkComponents
+  class AttributeMerger
+    def initialize(default_attributes:, user_attributes: {})
+      @default_attributes = default_attributes
+      @user_attributes = user_attributes
+    end
+
+    def merge
+      merge_attributes(@default_attributes, @user_attributes)
+    end
+
+    private
+    def merge_attributes(*args)
+      args.each_with_object({}) do |object, result|
+        result.merge!(object) do |_key, old, new|
+          case new
+          when Hash
+            merge_hashes(old, new)
+          when Array
+            merge_arrays(old, new)
+          when String
+            merge_strings(old, new)
+          else
+            new
+          end
+        end
+      end
+    end
+
+    def merge_hashes(old, new)
+      old.is_a?(Hash) ? merge_attributes(old, new) : new
+    end
+
+    def merge_arrays(old, new)
+      old.is_a?(Array) ? old + new : new
+    end
+
+    def merge_strings(old, new)
+      old.is_a?(String) ? "#{old} #{new}" : new
+    end
+  end
+end


### PR DESCRIPTION
Issue #9 

Implementa a classe `AttributeMerger` que permite concatenar os elementos de dois hashes pelas chaves. Exemplo:

```ruby
object1 = { list: [1, 2, 3], class: "bg-blue-500", child: { name: "child" } }
object2 = { list: [4, 5, 6], class: "text-blue-500", child: { name: "1" } }

atributte_merger = AttributeMerger.new(default_attributes: object1, user_attributes: object2)
attribute_merger.merge

# => { list: [1, 2, 3, 4, 5, 6], class: "bg-blue-500 text-blue-500", child: { name: "child 1" } }
```

