### PR TITLE
feat: Cria componente Text Area

### DIFF
--- a/app/components/ink_components/forms/text_area/component.html.erb
+++ b/app/components/ink_components/forms/text_area/component.html.erb
@@ -1,0 +1,1 @@
+<%= tag.textarea(**attributes) { attributes[:value] } %>

--- a/app/components/ink_components/forms/text_area/component.rb
+++ b/app/components/ink_components/forms/text_area/component.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module InkComponents
+  module Forms
+    module TextArea
+      class Component < ApplicationComponent
+        style do
+          base {
+            %w[
+              block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300
+              focus:ring-pink-500 focus:border-pink-500 dark:bg-gray-700 dark:border-gray-600
+              dark:placeholder-gray-400 dark:text-white dark:focus:ring-pink-500 dark:focus:border-pink-500
+            ]
+          }
+        end
+
+        def initialize(**extra_attributes)
+          super(**extra_attributes)
+        end
+
+        private
+        def default_attributes
+          { class: style }
+        end
+      end
+    end
+  end
+end

--- a/app/components/ink_components/forms/text_area/preview.rb
+++ b/app/components/ink_components/forms/text_area/preview.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module InkComponents
+  module Forms
+    module TextArea
+      class Preview < Lookbook::Preview
+        # @param placeholder text
+        # @param value text
+        # @param rows number
+        # @param cols number
+        def playground(placeholder: "Write your thoughts here...", value: nil, rows: nil, cols: nil)
+          render InkComponents::Forms::TextArea::Component.new(placeholder:, value:, rows:, cols:)
+        end
+      end
+    end
+  end
+end

--- a/spec/components/ink_components/forms/text_area_component_spec.rb
+++ b/spec/components/ink_components/forms/text_area_component_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe InkComponents::Forms::TextArea::Component, type: :component do
+  it "renders component" do
+    component = render_inline(described_class.new(placeholder: "Write something"))
+
+    expect(component.to_html).to include("textarea", "placeholder=\"Write something\"")
+  end
+end

--- a/spec/dummy/tailwind.config.js
+++ b/spec/dummy/tailwind.config.js
@@ -1,6 +1,7 @@
 const inkComponentsConfig = require("./ink_components.tailwind.config.js")
 
 module.exports = {
+  plugins: [require("flowbite/plugin")],
   darkMode: "class",
   content: [
     './app/views/**/*.html.erb',


### PR DESCRIPTION
O componente **Text Area** recebe a configuração:`extra_options`, onde será possível fornecer atributos HTML adicionais que podem ser aplicados ao componente. Como o id, name, rows, cols...

![image](https://github.com/user-attachments/assets/6d45fca3-c7d5-4ffb-bf57-dd147801d77a)
