### PR TITLE
feat: Cria componente File Input

### DIFF
--- a/app/components/ink_components/forms/file_input/component.html.erb
+++ b/app/components/ink_components/forms/file_input/component.html.erb
@@ -1,0 +1,2 @@
+<%= tag.input(**attributes) %>
+<%= helper_text %>

--- a/app/components/ink_components/forms/file_input/component.rb
+++ b/app/components/ink_components/forms/file_input/component.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module InkComponents
+  module Forms
+    module FileInput
+      class Component < ApplicationComponent
+        renders_one :helper_text, HelperText::Component
+
+        style do
+          base {
+            %w[
+              block w-full text-gray-900 border border-gray-300 rounded-lg cursor-pointer
+              bg-gray-50 dark:text-gray-400 focus:outline-none dark:bg-gray-700
+              dark:border-gray-600 dark:placeholder-gray-400
+            ]
+          }
+          variants {
+            size {
+              xs { "text-xs" }
+              sm { "text-sm" }
+              lg { "text-lg" }
+            }
+          }
+          defaults { { size: :sm } }
+        end
+
+        attr_reader :size
+
+        def initialize(size: nil, **extra_attributes)
+          @size = size
+
+          super(**extra_attributes)
+        end
+
+        private
+        def default_attributes
+          { class: style(size:), type: "file" }
+        end
+      end
+    end
+  end
+end

--- a/app/components/ink_components/forms/file_input/preview.rb
+++ b/app/components/ink_components/forms/file_input/preview.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module InkComponents
+  module Forms
+    module FileInput
+      class Preview < Lookbook::Preview
+        # @param size select { choices: [xs, sm, lg] }
+        def playground(size: :sm)
+          render InkComponents::Forms::FileInput::Component.new(size:)
+        end
+
+        # @!group Sizes
+        def extra_small
+          render InkComponents::Forms::FileInput::Component.new(size: :xs)
+        end
+
+        def small
+          render InkComponents::Forms::FileInput::Component.new(size: :sm)
+        end
+
+        def large
+          render InkComponents::Forms::FileInput::Component.new(size: :lg)
+        end
+        # @!endgroup
+
+        def with_helper_text
+          render InkComponents::Forms::FileInput::Component.new do |input|
+            input.with_helper_text { "SVG, PNG, JPG or GIF (MAX. 800x400px)." }
+          end
+        end
+
+        def with_multiple_files
+          render InkComponents::Forms::FileInput::Component.new(multiple: true)
+        end
+      end
+    end
+  end
+end

--- a/spec/components/ink_components/forms/file_input_component_spec.rb
+++ b/spec/components/ink_components/forms/file_input_component_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe InkComponents::Forms::FileInput::Component, type: :component do
+  it "renders component" do
+    component = render_inline(described_class.new)
+
+    expect(component.css("input").first["type"]).to include("file")
+  end
+
+  context "when the helper text slot is being used" do
+    it "renders the helper text" do
+      component = render_inline(described_class.new) do |input|
+        input.with_helper_text { "My helper text" }
+      end
+
+      expect(component.to_html).to include("My helper text")
+    end
+  end
+end

--- a/spec/dummy/tailwind.config.js
+++ b/spec/dummy/tailwind.config.js
@@ -1,6 +1,7 @@
 const inkComponentsConfig = require("./ink_components.tailwind.config.js")
 
 module.exports = {
+  plugins: [require("flowbite/plugin")],
   darkMode: "class",
   content: [
     './app/views/**/*.html.erb',


### PR DESCRIPTION
O componente `File Input` recebe as configurações:

Ele recebe as configurações:

- `size`: Define o tamanho do input. As opções disponíveis são xs (extra small), sm (small) e lg (large).
- `extra_options`: Atributos HTML adicionais que podem ser aplicados ao componente.

![image](https://github.com/user-attachments/assets/e86fdeef-126f-4216-b06d-41547bd4b879)
![image](https://github.com/user-attachments/assets/fac9590e-9785-4f74-8175-ec54a56438b9)
