### PR TITLE
feat: Cria componente Progress Bar

### DIFF
--- a/app/components/ink_components/progress_bar/component.html.erb
+++ b/app/components/ink_components/progress_bar/component.html.erb
@@ -1,12 +1,13 @@
 
 <% if progress_on_top? %>
   <div class="flex justify-between mb-1">
-    <%= content_tag :span, "#{progress}%", class: style(:label, color:) %>
+    <%= content_tag :span, content, class: style(:label, color:) %>
+    <%= content_tag :span, display_progress, class: style(:label, color:) %>
   </div>
 <% end %>
 
 <%= content_tag :div, attributes do %>
   <%= content_tag :div, inner_bar_attributes do %>
-    <%= progress if progress_inside? %>
+    <%= display_progress if progress_inside? %>
   <% end %>
 <% end %>

--- a/app/components/ink_components/progress_bar/component.rb
+++ b/app/components/ink_components/progress_bar/component.rb
@@ -83,7 +83,14 @@ module InkComponents
       end
 
       def inner_bar_attributes
-        { class: style(:inner_bar, size: size_option, color:, progress_position:), style: "width: #{progress}%" }
+        {
+          class: style(:inner_bar, size: size_option, color:, progress_position:),
+          style: "width: #{display_progress}"
+        }
+      end
+
+      def display_progress
+        "#{progress}%"
       end
 
       def size_option

--- a/app/components/ink_components/progress_bar/preview.rb
+++ b/app/components/ink_components/progress_bar/preview.rb
@@ -3,12 +3,13 @@
 module InkComponents
   module ProgressBar
     class Preview < Lookbook::Preview
+      # @param content text
       # @param progress number
       # @param progress_position select { choices: [none, inside, top] }
       # @param size select { choices: [sm, md, lg, xl] }
       # @param color select { choices: [pink, dark, blue, red, green, yellow, indigo, purple] }
-      def playground(size: :md, color: :pink, progress: 45, progress_position: :inside)
-        render InkComponents::ProgressBar::Component.new(size:, color:, progress:, progress_position:)
+      def playground(size: :md, color: :pink, progress: 45, progress_position: :inside, content: nil)
+        render(InkComponents::ProgressBar::Component.new(size:, color:, progress:, progress_position:)) { content }
       end
 
       # @!group Sizes
@@ -60,13 +61,13 @@ module InkComponents
       # @!endgroup
 
       # @!group Progress Positions
-      # @label Inside (In this option, the progress bar size remains fixed, with "md" set as the default.)
+      # @label Inside (In this option, the progress bar size remains fixed)
       def inside
         render InkComponents::ProgressBar::Component.new(progress_position: :inside, progress: 45)
       end
 
       def top
-        render InkComponents::ProgressBar::Component.new(progress_position: :top, progress: 45)
+        render(InkComponents::ProgressBar::Component.new(progress_position: :top, progress: 45)) { "Progress" }
       end
       # @!endgroup
     end

--- a/spec/components/ink_components/progress_bar_component_spec.rb
+++ b/spec/components/ink_components/progress_bar_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe InkComponents::ProgressBar::Component, type: :component do
       it "renders the progress indicator inside an inner bar" do
         component = render_inline(described_class.new(progress: 45, progress_position: :inside))
 
-        expect(component.css("div").last.text).to include("45")
+        expect(component.css("div").last.text).to include("45%")
       end
 
       it "doesn't render a span tag to display progress" do


### PR DESCRIPTION
O componente `Progress Bar` recebe as configurações:

- `progress`: Recebe o progresso atual da barra, é um campo obrigatório e deve ser um número.
- `progress_position`: Define a posição do indicador de progresso (número que passamos em progress). As opções disponíveis são inside (dentro da barra), top (em cima da barra) ou nil (quando queremos mostrar o indicador).
- `size`: Define o tamanho da barra. As opções disponíveis são sm (small), md (medium), lg (large) e xl (extra large).
- `color`: Define a cor da barra. As opções disponíveis são pink, blue, red, green, yellow, indigo e purple.
- `extra_options`: Atributos HTML adicionais que podem ser aplicados ao componente.

**OBSERVAÇÃO:**
Quando configuramos a posição do indicador de progresso para 'dentro' da barra, o componente mantém um tamanho médio por padrão. Isso ocorre porque, se alterarmos o tamanho da barra, a posição do número pode ficar desalinhada. 

**Se possível, acesse o Lookbook da branch para um melhor entendimento.**