### PR TITLE
fix: Corrige parâmetros do componente Checkbox

### DIFF
--- a/app/components/ink_components/forms/checkbox/component.html.erb
+++ b/app/components/ink_components/forms/checkbox/component.html.erb
@@ -1,6 +1,6 @@
 <%= content_tag :div, wrapper_div_attributes do %>
   <%= hidden_field_tag checkbox_name, unchecked_value, id: nil %>
-  <%= check_box_tag checkbox_name, checked_value, attributes %>
+  <%= check_box_tag checkbox_name, checked_value, checked, attributes %>
   <%= content_tag :div, content_container_div_attributes do %>
     <%= render(InkComponents::Forms::Label::Component.new(**label_attributes)) { content } %>
     <%= helper_text %>

--- a/app/components/ink_components/forms/checkbox/component.rb
+++ b/app/components/ink_components/forms/checkbox/component.rb
@@ -67,11 +67,12 @@ module InkComponents
           }
         end
 
-        attr_reader :checked_value, :unchecked_value, :disabled, :bordered, :color
+        attr_reader :checked_value, :unchecked_value, :checked, :disabled, :bordered, :color
 
-        def initialize(checked_value: "1", unchecked_value: "0", disabled: false, bordered: false, color: nil, **extra_attributes)
+        def initialize(checked_value: "1", unchecked_value: "0", checked: false, disabled: false, bordered: false, color: nil, **extra_attributes)
           @checked_value = checked_value
           @unchecked_value = unchecked_value
+          @checked = checked
           @disabled = disabled
           @bordered = bordered
           @color = color


### PR DESCRIPTION
A partir da versão 7.1.3.2 do Rails, os parâmetros do método check_box_tag mudaram:

```
- check_box_tag(name, value = "1", checked = false, options = {})
+ check_box_tag(name, *args)
```
Dessa forma, as classes do componente Checkbox não estão sendo renderizadas corretamente em aplicações Rails 6.1.0. Para resolver esse problema, precisamos adicionar o parâmetro `checked` explicitamente, uma vez que o mesmo estava sendo passado via `extra_attributes`.

**Lookbook do Monolito:**

![image](https://github.com/user-attachments/assets/5c83d7c2-b84a-47f6-8733-a94de92a52a5)
