### PR TITLE
refactor: Utiliza método do view helper nos previews dos componentes

### DIFF
--- a/app/components/ink_components/avatar/preview.rb
+++ b/app/components/ink_components/avatar/preview.rb
@@ -9,63 +9,63 @@ module InkComponents
       # @param shape select { choices: [circle, square] }
       # @param bordered toggle
       def playground(image_url: "https://i.pravatar.cc/150?img=3", name_abbreviation: nil, size: :md, shape: :circle, bordered: false)
-        render InkComponents::Avatar::Component.new(image_url:, name_abbreviation:, size:, shape:, bordered:)
+        avatar_component(image_url:, name_abbreviation:, size:, shape:, bordered:)
       end
 
       # @!group Sizes
       def extra_small
-        render InkComponents::Avatar::Component.new(image_url: "https://i.pravatar.cc/150?img=3", size: :xs)
+        avatar_component(image_url: "https://i.pravatar.cc/150?img=3", size: :xs)
       end
 
       def small
-        render InkComponents::Avatar::Component.new(image_url: "https://i.pravatar.cc/150?img=3", size: :sm)
+        avatar_component(image_url: "https://i.pravatar.cc/150?img=3", size: :sm)
       end
 
       def medium
-        render InkComponents::Avatar::Component.new(image_url: "https://i.pravatar.cc/150?img=3", size: :md)
+        avatar_component(image_url: "https://i.pravatar.cc/150?img=3", size: :md)
       end
 
       def large
-        render InkComponents::Avatar::Component.new(image_url: "https://i.pravatar.cc/150?img=3", size: :lg)
+        avatar_component(image_url: "https://i.pravatar.cc/150?img=3", size: :lg)
       end
 
       def extra_large
-        render InkComponents::Avatar::Component.new(image_url: "https://i.pravatar.cc/150?img=3", size: :xl)
+        avatar_component(image_url: "https://i.pravatar.cc/150?img=3", size: :xl)
       end
       # @!endgroup
 
       # @!group Shapes
       def circle
-        render InkComponents::Avatar::Component.new(image_url: "https://i.pravatar.cc/150?img=3", shape: :circle)
+        avatar_component(image_url: "https://i.pravatar.cc/150?img=3", shape: :circle)
       end
 
       def square
-        render InkComponents::Avatar::Component.new(image_url: "https://i.pravatar.cc/150?img=3", shape: :square)
+        avatar_component(image_url: "https://i.pravatar.cc/150?img=3", shape: :square)
       end
       # @!endgroup
 
       # @!group Border
       def with_border
-        render InkComponents::Avatar::Component.new(image_url: "https://i.pravatar.cc/150?img=3", bordered: true)
+        avatar_component(image_url: "https://i.pravatar.cc/150?img=3", bordered: true)
       end
 
       def without_border
-        render InkComponents::Avatar::Component.new(image_url: "https://i.pravatar.cc/150?img=3", bordered: false)
+        avatar_component(image_url: "https://i.pravatar.cc/150?img=3", bordered: false)
       end
       # @!endgroup
 
       # @!group Placeholders
       def name_abbreviation
-        render InkComponents::Avatar::Component.new(name_abbreviation: "JL")
+        avatar_component(name_abbreviation: "JL")
       end
 
       def icon
-        render InkComponents::Avatar::Component.new
+        avatar_component
       end
       # @!endgroup
 
       def with_text
-        render InkComponents::Avatar::Component.new do |avatar|
+        avatar_component do |avatar|
           avatar.with_text do
             content_tag(:p, "Jese Leos", class: "font-medium dark:text-white").concat(
               content_tag(:p, "Joined in August 2014", class: "text-sm text-gray-500 dark:text-gray-400")

--- a/app/components/ink_components/avatar_collection/preview.rb
+++ b/app/components/ink_components/avatar_collection/preview.rb
@@ -8,7 +8,7 @@ module InkComponents
       # @param shape select { choices: [circle, square] }
       # @param href text
       def playground(avatar_count: 5, size: :md, shape: :circle, href: nil)
-        render InkComponents::AvatarCollection::Component.new(size:, shape:, href:) do |component|
+        avatar_collection_component(size:, shape:, href:) do |component|
           avatar_count.times do |i|
             component.with_avatar(image_url: "https://i.pravatar.cc/150?img=#{i + 1}")
           end
@@ -17,20 +17,20 @@ module InkComponents
 
       # @!group Numbers of Avatars
       def with_1_avatar
-        render InkComponents::AvatarCollection::Component.new do |component|
+        avatar_collection_component do |component|
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=1")
         end
       end
 
       def with_2_avatars
-        render InkComponents::AvatarCollection::Component.new do |component|
+        avatar_collection_component do |component|
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=1")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=2")
         end
       end
 
       def with_3_avatars
-        render InkComponents::AvatarCollection::Component.new do |component|
+        avatar_collection_component do |component|
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=1")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=2")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=3")
@@ -38,7 +38,7 @@ module InkComponents
       end
 
       def with_4_avatars
-        render InkComponents::AvatarCollection::Component.new do |component|
+        avatar_collection_component do |component|
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=1")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=2")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=3")
@@ -47,7 +47,7 @@ module InkComponents
       end
 
       def with_5_avatars
-        render InkComponents::AvatarCollection::Component.new do |component|
+        avatar_collection_component do |component|
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=1")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=2")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=3")
@@ -58,7 +58,7 @@ module InkComponents
       # @!endgroup
 
       def with_href
-        render InkComponents::AvatarCollection::Component.new(href: "www.example.com") do |component|
+        avatar_collection_component(href: "www.example.com") do |component|
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=1")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=2")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=3")
@@ -69,7 +69,7 @@ module InkComponents
 
       # @!group Sizes
       def extra_small
-        render InkComponents::AvatarCollection::Component.new(size: :xs) do |component|
+        avatar_collection_component(size: :xs) do |component|
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=1")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=2")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=3")
@@ -79,7 +79,7 @@ module InkComponents
       end
 
       def small
-        render InkComponents::AvatarCollection::Component.new(size: :sm) do |component|
+        avatar_collection_component(size: :sm) do |component|
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=1")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=2")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=3")
@@ -89,7 +89,7 @@ module InkComponents
       end
 
       def medium
-        render InkComponents::AvatarCollection::Component.new(size: :md) do |component|
+        avatar_collection_component(size: :md) do |component|
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=1")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=2")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=3")
@@ -99,7 +99,7 @@ module InkComponents
       end
 
       def large
-        render InkComponents::AvatarCollection::Component.new(size: :lg) do |component|
+        avatar_collection_component(size: :lg) do |component|
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=1")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=2")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=3")
@@ -109,7 +109,7 @@ module InkComponents
       end
 
       def extra_large
-        render InkComponents::AvatarCollection::Component.new(size: :xl) do |component|
+        avatar_collection_component(size: :xl) do |component|
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=1")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=2")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=3")
@@ -121,7 +121,7 @@ module InkComponents
 
       # @!group Shapes
       def circle
-        render InkComponents::AvatarCollection::Component.new do |component|
+        avatar_collection_component do |component|
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=1")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=2")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=3")
@@ -131,7 +131,7 @@ module InkComponents
       end
 
       def square
-        render InkComponents::AvatarCollection::Component.new(shape: :square) do |component|
+        avatar_collection_component(shape: :square) do |component|
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=1")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=2")
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=3")

--- a/app/components/ink_components/avatar_status/preview.rb
+++ b/app/components/ink_components/avatar_status/preview.rb
@@ -5,20 +5,20 @@ module InkComponents
       # @param position select { choices: [top, bottom] }
       # @param avatar_shape select { choices: [circle, square] }
       def playground(status: :online, position: :top, avatar_shape: :circle)
-        render InkComponents::AvatarStatus::Component.new(status:, position:, avatar_shape:) do |component|
+        avatar_status_component(status:, position:, avatar_shape:) do |component|
           component.with_avatar(shape: avatar_shape, image_url: "https://i.pravatar.cc/150?img=3")
         end
       end
 
       # @!group Status
       def online
-        render InkComponents::AvatarStatus::Component.new(status: :online) do |component|
+        avatar_status_component(status: :online) do |component|
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=3")
         end
       end
 
       def offline
-        render InkComponents::AvatarStatus::Component.new(status: :offline) do |component|
+        avatar_status_component(status: :offline) do |component|
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=3")
         end
       end
@@ -26,25 +26,25 @@ module InkComponents
 
       # @!group Positions
       def top_with_circle_avatar
-        render InkComponents::AvatarStatus::Component.new(position: :top) do |component|
+        avatar_status_component(position: :top) do |component|
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=3")
         end
       end
 
       def top_with_square_avatar
-        render InkComponents::AvatarStatus::Component.new(position: :top, avatar_shape: :square) do |component|
+        avatar_status_component(position: :top, avatar_shape: :square) do |component|
           component.with_avatar(shape: :square, image_url: "https://i.pravatar.cc/150?img=3")
         end
       end
 
       def bottom_with_circle_avatar
-        render InkComponents::AvatarStatus::Component.new(position: :bottom) do |component|
+        avatar_status_component(position: :bottom) do |component|
           component.with_avatar(image_url: "https://i.pravatar.cc/150?img=3")
         end
       end
 
       def bottom_with_square_avatar
-        render InkComponents::AvatarStatus::Component.new(position: :bottom, avatar_shape: :square) do |component|
+        avatar_status_component(position: :bottom, avatar_shape: :square) do |component|
           component.with_avatar(shape: :square, image_url: "https://i.pravatar.cc/150?img=3")
         end
       end

--- a/app/components/ink_components/badge/preview.rb
+++ b/app/components/ink_components/badge/preview.rb
@@ -9,90 +9,90 @@ module InkComponents
       # @param href text
       # @param dismissible select { choices: [true, false] }
       def playground(content: "Some text", color: :pink, size: :xs, bordered: false, shape: :square, href: nil, dismissible: false)
-        render InkComponents::Badge::Component.new(id: "badge_component", size:, color:, bordered:, shape:, href:, dismissible:).with_content(content)
+        badge_component(id: "badge_component", size:, color:, bordered:, shape:, href:, dismissible:).with_content(content)
       end
 
       # @!group Colors
       def pink
-        render InkComponents::Badge::Component.new(color: :pink).with_content("Pink Badge")
+        badge_component(color: :pink).with_content("Pink Badge")
       end
 
       def dark
-        render InkComponents::Badge::Component.new(color: :dark).with_content("Dark Badge")
+        badge_component(color: :dark).with_content("Dark Badge")
       end
 
       def blue
-        render InkComponents::Badge::Component.new(color: :blue).with_content("Blue Badge")
+        badge_component(color: :blue).with_content("Blue Badge")
       end
 
       def red
-        render InkComponents::Badge::Component.new(color: :red).with_content("Red Badge")
+        badge_component(color: :red).with_content("Red Badge")
       end
 
       def green
-        render InkComponents::Badge::Component.new(color: :green).with_content("Green Badge")
+        badge_component(color: :green).with_content("Green Badge")
       end
 
       def yellow
-        render InkComponents::Badge::Component.new(color: :yellow).with_content("Yellow Badge")
+        badge_component(color: :yellow).with_content("Yellow Badge")
       end
 
       def indigo
-        render InkComponents::Badge::Component.new(color: :indigo).with_content("Indigo Badge")
+        badge_component(color: :indigo).with_content("Indigo Badge")
       end
 
       def purple
-        render InkComponents::Badge::Component.new(color: :purple).with_content("Purple Badge")
+        badge_component(color: :purple).with_content("Purple Badge")
       end
       # @!endgroup
 
       # @!group Sizes
       def large
-        render InkComponents::Badge::Component.new(size: :sm).with_content("Large")
+        badge_component(size: :sm).with_content("Large")
       end
 
       def small
-        render InkComponents::Badge::Component.new(size: :xs).with_content("Small")
+        badge_component(size: :xs).with_content("Small")
       end
       # @!endgroup
 
       # @!group Border
       def bordered_true
-        render InkComponents::Badge::Component.new(bordered: true).with_content("Bordered Badge")
+        badge_component(bordered: true).with_content("Bordered Badge")
       end
 
       def bordered_false
-        render InkComponents::Badge::Component.new(bordered: false).with_content("Non-Bordered Badge")
+        badge_component(bordered: false).with_content("Non-Bordered Badge")
       end
       # @!endgroup
 
       # @!group Shape
       def square_shape
-        render InkComponents::Badge::Component.new(shape: :square).with_content("Square Badge")
+        badge_component(shape: :square).with_content("Square Badge")
       end
 
       def pill_shape
-        render InkComponents::Badge::Component.new(shape: :pill).with_content("Pill Badge")
+        badge_component(shape: :pill).with_content("Pill Badge")
       end
       # @!endgroup
 
       # @!group Href
       def href_present
-        render InkComponents::Badge::Component.new(href: "https://example.com").with_content("Badge with Href")
+        badge_component(href: "https://example.com").with_content("Badge with Href")
       end
 
       def href_absent
-        render InkComponents::Badge::Component.new(href: nil).with_content("Badge without Href")
+        badge_component(href: nil).with_content("Badge without Href")
       end
       # @!endgroup
 
       # @!group Dismissible
       def dismissible_true
-        render InkComponents::Badge::Component.new(id: "badge_component", dismissible: true).with_content("dismissible Badge")
+        badge_component(id: "badge_component", dismissible: true).with_content("dismissible Badge")
       end
 
       def dismissible_false
-        render InkComponents::Badge::Component.new(dismissible: false).with_content("Non-dismissible Badge")
+        badge_component(dismissible: false).with_content("Non-dismissible Badge")
       end
       # @!endgroup
     end

--- a/app/components/ink_components/badge/preview.rb
+++ b/app/components/ink_components/badge/preview.rb
@@ -9,90 +9,90 @@ module InkComponents
       # @param href text
       # @param dismissible select { choices: [true, false] }
       def playground(content: "Some text", color: :pink, size: :xs, bordered: false, shape: :square, href: nil, dismissible: false)
-        badge_component(id: "badge_component", size:, color:, bordered:, shape:, href:, dismissible:).with_content(content)
+        badge_component(id: "badge_component", size:, color:, bordered:, shape:, href:, dismissible:) { content }
       end
 
       # @!group Colors
       def pink
-        badge_component(color: :pink).with_content("Pink Badge")
+        badge_component(color: :pink) { "Pink Badge" }
       end
 
       def dark
-        badge_component(color: :dark).with_content("Dark Badge")
+        badge_component(color: :dark) { "Dark Badge" }
       end
 
       def blue
-        badge_component(color: :blue).with_content("Blue Badge")
+        badge_component(color: :blue) { "Blue Badge" }
       end
 
       def red
-        badge_component(color: :red).with_content("Red Badge")
+        badge_component(color: :red) { "Red Badge" }
       end
 
       def green
-        badge_component(color: :green).with_content("Green Badge")
+        badge_component(color: :green) { "Green Badge" }
       end
 
       def yellow
-        badge_component(color: :yellow).with_content("Yellow Badge")
+        badge_component(color: :yellow) { "Yellow Badge" }
       end
 
       def indigo
-        badge_component(color: :indigo).with_content("Indigo Badge")
+        badge_component(color: :indigo) { "Indigo Badge" }
       end
 
       def purple
-        badge_component(color: :purple).with_content("Purple Badge")
+        badge_component(color: :purple) { "Purple Badge" }
       end
       # @!endgroup
 
       # @!group Sizes
       def large
-        badge_component(size: :sm).with_content("Large")
+        badge_component(size: :sm) { "Large" }
       end
 
       def small
-        badge_component(size: :xs).with_content("Small")
+        badge_component(size: :xs) { "Small" }
       end
       # @!endgroup
 
       # @!group Border
       def bordered_true
-        badge_component(bordered: true).with_content("Bordered Badge")
+        badge_component(bordered: true) { "Bordered Badge" }
       end
 
       def bordered_false
-        badge_component(bordered: false).with_content("Non-Bordered Badge")
+        badge_component(bordered: false) { "Non-Bordered Badge" }
       end
       # @!endgroup
 
       # @!group Shape
       def square_shape
-        badge_component(shape: :square).with_content("Square Badge")
+        badge_component(shape: :square) { "Square Badge" }
       end
 
       def pill_shape
-        badge_component(shape: :pill).with_content("Pill Badge")
+        badge_component(shape: :pill) { "Pill Badge" }
       end
       # @!endgroup
 
       # @!group Href
       def href_present
-        badge_component(href: "https://example.com").with_content("Badge with Href")
+        badge_component(href: "https://example.com") { "Badge with Href" }
       end
 
       def href_absent
-        badge_component(href: nil).with_content("Badge without Href")
+        badge_component(href: nil) { "Badge without Href" }
       end
       # @!endgroup
 
       # @!group Dismissible
       def dismissible_true
-        badge_component(id: "badge_component", dismissible: true).with_content("dismissible Badge")
+        badge_component(id: "badge_component", dismissible: true) { "dismissible Badge" }
       end
 
       def dismissible_false
-        badge_component(dismissible: false).with_content("Non-dismissible Badge")
+        badge_component(dismissible: false) { "Non-dismissible Badge" }
       end
       # @!endgroup
     end

--- a/app/components/ink_components/button/preview.rb
+++ b/app/components/ink_components/button/preview.rb
@@ -11,197 +11,197 @@ module InkComponents
       # @param size select { choices: [xs, sm, md, lg, xl] }
       # @param shape select { choices: [default, pill, outline] }
       def playground(builder: :link_to, href: "#", disabled: false, color: :pink, shape: :default, size: :md, content: "Button")
-        button_component(builder:, href:, disabled:, color:, shape:, size:)) { content }
+        button_component(builder:, href:, disabled:, color:, shape:, size:) { content }
       end
 
       # @!group Builders
       def link_to_builder
-        button_component(builder: :link_to, href: "#")) { "Button" }
+        button_component(builder: :link_to, href: "#") { "Button" }
       end
 
       def button_tag_builder
-        button_component(builder: :button_tag)) { "Button" }
+        button_component(builder: :button_tag) { "Button" }
       end
 
       def button_to_builder
         button_component(
           builder: :button_to,
           href: InkComponents::Engine.routes.url_helpers.lookbook_path,
-          form: { data: { type: :json } })
+          form: { data: { type: :json } }
         ) { "Button" }
       end
       # @!endgroup
 
       # @!group Sizes
       def extra_small
-        button_component(size: :xs)) { "Extra small" }
+        button_component(size: :xs) { "Extra small" }
       end
 
       def small
-        button_component(size: :sm)) { "Small" }
+        button_component(size: :sm) { "Small" }
       end
 
       def medium
-        button_component(size: :md)) { "Medium" }
+        button_component(size: :md) { "Medium" }
       end
 
       def large
-        button_component(size: :lg)) { "Large" }
+        button_component(size: :lg) { "Large" }
       end
 
       def extra_large
-        button_component(size: :xl)) { "Extra large" }
+        button_component(size: :xl) { "Extra large" }
       end
       # @!endgroup
 
       # @!group Shapes
       def default
-        button_component(shape: :default)) { "Default" }
+        button_component(shape: :default) { "Default" }
       end
 
       def pill
-        button_component(shape: :pill)) { "Pill" }
+        button_component(shape: :pill) { "Pill" }
       end
 
       def outline
-        button_component(shape: :outline)) { "Outline" }
+        button_component(shape: :outline) { "Outline" }
       end
       # @!endgroup
 
       # @!group Colors
       def alternative
-        button_component(color: :alternative)) { "Alternative" }
+        button_component(color: :alternative) { "Alternative" }
       end
 
       def light
-        button_component(color: :light)) { "Light" }
+        button_component(color: :light) { "Light" }
       end
 
       def pink
-        button_component(color: :pink)) { "Pink" }
+        button_component(color: :pink) { "Pink" }
       end
 
       def blue
-        button_component(color: :blue)) { "Blue" }
+        button_component(color: :blue) { "Blue" }
       end
 
       def dark
-        button_component(color: :dark)) { "Dark" }
+        button_component(color: :dark) { "Dark" }
       end
 
       def green
-        button_component(color: :green)) { "Green" }
+        button_component(color: :green) { "Green" }
       end
 
       def red
-        button_component(color: :red)) { "Red" }
+        button_component(color: :red) { "Red" }
       end
 
       def yellow
-        button_component(color: :yellow)) { "Yellow" }
+        button_component(color: :yellow) { "Yellow" }
       end
 
       def purple
-        button_component(color: :purple)) { "Purple" }
+        button_component(color: :purple) { "Purple" }
       end
       # @!endgroup
 
       # @!group Outline Colors
       def pink_outline
-        button_component(color: :pink, shape: :outline)) { "Pink Outline" }
+        button_component(color: :pink, shape: :outline) { "Pink Outline" }
       end
 
       def blue_outline
-        button_component(color: :blue, shape: :outline)) { "Blue Outline" }
+        button_component(color: :blue, shape: :outline) { "Blue Outline" }
       end
 
       def dark_outline
-        button_component(color: :dark, shape: :outline)) { "Dark Outline" }
+        button_component(color: :dark, shape: :outline) { "Dark Outline" }
       end
 
       def green_outline
-        button_component(color: :green, shape: :outline)) { "Green Outline" }
+        button_component(color: :green, shape: :outline) { "Green Outline" }
       end
 
       def red_outline
-        button_component(color: :red, shape: :outline)) { "Red Outline" }
+        button_component(color: :red, shape: :outline) { "Red Outline" }
       end
 
       def yellow_outline
-        button_component(color: :yellow, shape: :outline)) { "Yellow Outline" }
+        button_component(color: :yellow, shape: :outline) { "Yellow Outline" }
       end
 
       def purple_outline
-        button_component(color: :purple, shape: :outline)) { "Purple Outline" }
+        button_component(color: :purple, shape: :outline) { "Purple Outline" }
       end
       # @!endgroup
 
 
       # @!group Disabled
       def alternative_disabled
-        button_component(color: :alternative, disabled: true)) { "Disabled" }
+        button_component(color: :alternative, disabled: true) { "Disabled" }
       end
 
       def light_disabled
-        button_component(color: :light, disabled: true)) { "Disabled" }
+        button_component(color: :light, disabled: true) { "Disabled" }
       end
 
       def pink_disabled
-        button_component(color: :pink, disabled: true)) { "Disabled" }
+        button_component(color: :pink, disabled: true) { "Disabled" }
       end
 
       def blue_disabled
-        button_component(color: :blue, disabled: true)) { "Disabled" }
+        button_component(color: :blue, disabled: true) { "Disabled" }
       end
 
       def dark_disabled
-        button_component(color: :dark, disabled: true)) { "Disabled" }
+        button_component(color: :dark, disabled: true) { "Disabled" }
       end
 
       def green_disabled
-        button_component(color: :green, disabled: true)) { "Disabled" }
+        button_component(color: :green, disabled: true) { "Disabled" }
       end
 
       def red_disabled
-        button_component(color: :red, disabled: true)) { "Disabled" }
+        button_component(color: :red, disabled: true) { "Disabled" }
       end
 
       def yellow_disabled
-        button_component(color: :yellow, disabled: true)) { "Disabled" }
+        button_component(color: :yellow, disabled: true) { "Disabled" }
       end
 
       def purple_disabled
-        button_component(color: :purple, disabled: true)) { "Disabled" }
+        button_component(color: :purple, disabled: true) { "Disabled" }
       end
       # @!endgroup
 
       # @!group Outline Disabled
       def pink_disabled_outline
-        button_component(shape: :outline, color: :pink, disabled: true)) { "Disabled" }
+        button_component(shape: :outline, color: :pink, disabled: true) { "Disabled" }
       end
 
       def blue_disabled_outline
-        button_component(shape: :outline, color: :blue, disabled: true)) { "Disabled" }
+        button_component(shape: :outline, color: :blue, disabled: true) { "Disabled" }
       end
 
       def dark_disabled_outline
-        button_component(shape: :outline, color: :dark, disabled: true)) { "Disabled" }
+        button_component(shape: :outline, color: :dark, disabled: true) { "Disabled" }
       end
 
       def green_disabled_outline
-        button_component(shape: :outline, color: :green, disabled: true)) { "Disabled" }
+        button_component(shape: :outline, color: :green, disabled: true) { "Disabled" }
       end
 
       def red_disabled_outline
-        button_component(shape: :outline, color: :red, disabled: true)) { "Disabled" }
+        button_component(shape: :outline, color: :red, disabled: true) { "Disabled" }
       end
 
       def yellow_disabled_outline
-        button_component(shape: :outline, color: :yellow, disabled: true)) { "Disabled" }
+        button_component(shape: :outline, color: :yellow, disabled: true) { "Disabled" }
       end
 
       def purple_disabled_outline
-        button_component(shape: :outline, color: :purple, disabled: true)) { "Disabled" }
+        button_component(shape: :outline, color: :purple, disabled: true) { "Disabled" }
       end
       # @!endgroup
     end

--- a/app/components/ink_components/button/preview.rb
+++ b/app/components/ink_components/button/preview.rb
@@ -11,20 +11,20 @@ module InkComponents
       # @param size select { choices: [xs, sm, md, lg, xl] }
       # @param shape select { choices: [default, pill, outline] }
       def playground(builder: :link_to, href: "#", disabled: false, color: :pink, shape: :default, size: :md, content: "Button")
-        render(InkComponents::Button::Component.new(builder:, href:, disabled:, color:, shape:, size:)) { content }
+        button_component(builder:, href:, disabled:, color:, shape:, size:)) { content }
       end
 
       # @!group Builders
       def link_to_builder
-        render(InkComponents::Button::Component.new(builder: :link_to, href: "#")) { "Button" }
+        button_component(builder: :link_to, href: "#")) { "Button" }
       end
 
       def button_tag_builder
-        render(InkComponents::Button::Component.new(builder: :button_tag)) { "Button" }
+        button_component(builder: :button_tag)) { "Button" }
       end
 
       def button_to_builder
-        render(InkComponents::Button::Component.new(
+        button_component(
           builder: :button_to,
           href: InkComponents::Engine.routes.url_helpers.lookbook_path,
           form: { data: { type: :json } })
@@ -34,174 +34,174 @@ module InkComponents
 
       # @!group Sizes
       def extra_small
-        render(InkComponents::Button::Component.new(size: :xs)) { "Extra small" }
+        button_component(size: :xs)) { "Extra small" }
       end
 
       def small
-        render(InkComponents::Button::Component.new(size: :sm)) { "Small" }
+        button_component(size: :sm)) { "Small" }
       end
 
       def medium
-        render(InkComponents::Button::Component.new(size: :md)) { "Medium" }
+        button_component(size: :md)) { "Medium" }
       end
 
       def large
-        render(InkComponents::Button::Component.new(size: :lg)) { "Large" }
+        button_component(size: :lg)) { "Large" }
       end
 
       def extra_large
-        render(InkComponents::Button::Component.new(size: :xl)) { "Extra large" }
+        button_component(size: :xl)) { "Extra large" }
       end
       # @!endgroup
 
       # @!group Shapes
       def default
-        render(InkComponents::Button::Component.new(shape: :default)) { "Default" }
+        button_component(shape: :default)) { "Default" }
       end
 
       def pill
-        render(InkComponents::Button::Component.new(shape: :pill)) { "Pill" }
+        button_component(shape: :pill)) { "Pill" }
       end
 
       def outline
-        render(InkComponents::Button::Component.new(shape: :outline)) { "Outline" }
+        button_component(shape: :outline)) { "Outline" }
       end
       # @!endgroup
 
       # @!group Colors
       def alternative
-        render(InkComponents::Button::Component.new(color: :alternative)) { "Alternative" }
+        button_component(color: :alternative)) { "Alternative" }
       end
 
       def light
-        render(InkComponents::Button::Component.new(color: :light)) { "Light" }
+        button_component(color: :light)) { "Light" }
       end
 
       def pink
-        render(InkComponents::Button::Component.new(color: :pink)) { "Pink" }
+        button_component(color: :pink)) { "Pink" }
       end
 
       def blue
-        render(InkComponents::Button::Component.new(color: :blue)) { "Blue" }
+        button_component(color: :blue)) { "Blue" }
       end
 
       def dark
-        render(InkComponents::Button::Component.new(color: :dark)) { "Dark" }
+        button_component(color: :dark)) { "Dark" }
       end
 
       def green
-        render(InkComponents::Button::Component.new(color: :green)) { "Green" }
+        button_component(color: :green)) { "Green" }
       end
 
       def red
-        render(InkComponents::Button::Component.new(color: :red)) { "Red" }
+        button_component(color: :red)) { "Red" }
       end
 
       def yellow
-        render(InkComponents::Button::Component.new(color: :yellow)) { "Yellow" }
+        button_component(color: :yellow)) { "Yellow" }
       end
 
       def purple
-        render(InkComponents::Button::Component.new(color: :purple)) { "Purple" }
+        button_component(color: :purple)) { "Purple" }
       end
       # @!endgroup
 
       # @!group Outline Colors
       def pink_outline
-        render(InkComponents::Button::Component.new(color: :pink, shape: :outline)) { "Pink Outline" }
+        button_component(color: :pink, shape: :outline)) { "Pink Outline" }
       end
 
       def blue_outline
-        render(InkComponents::Button::Component.new(color: :blue, shape: :outline)) { "Blue Outline" }
+        button_component(color: :blue, shape: :outline)) { "Blue Outline" }
       end
 
       def dark_outline
-        render(InkComponents::Button::Component.new(color: :dark, shape: :outline)) { "Dark Outline" }
+        button_component(color: :dark, shape: :outline)) { "Dark Outline" }
       end
 
       def green_outline
-        render(InkComponents::Button::Component.new(color: :green, shape: :outline)) { "Green Outline" }
+        button_component(color: :green, shape: :outline)) { "Green Outline" }
       end
 
       def red_outline
-        render(InkComponents::Button::Component.new(color: :red, shape: :outline)) { "Red Outline" }
+        button_component(color: :red, shape: :outline)) { "Red Outline" }
       end
 
       def yellow_outline
-        render(InkComponents::Button::Component.new(color: :yellow, shape: :outline)) { "Yellow Outline" }
+        button_component(color: :yellow, shape: :outline)) { "Yellow Outline" }
       end
 
       def purple_outline
-        render(InkComponents::Button::Component.new(color: :purple, shape: :outline)) { "Purple Outline" }
+        button_component(color: :purple, shape: :outline)) { "Purple Outline" }
       end
       # @!endgroup
 
 
       # @!group Disabled
       def alternative_disabled
-        render(InkComponents::Button::Component.new(color: :alternative, disabled: true)) { "Disabled" }
+        button_component(color: :alternative, disabled: true)) { "Disabled" }
       end
 
       def light_disabled
-        render(InkComponents::Button::Component.new(color: :light, disabled: true)) { "Disabled" }
+        button_component(color: :light, disabled: true)) { "Disabled" }
       end
 
       def pink_disabled
-        render(InkComponents::Button::Component.new(color: :pink, disabled: true)) { "Disabled" }
+        button_component(color: :pink, disabled: true)) { "Disabled" }
       end
 
       def blue_disabled
-        render(InkComponents::Button::Component.new(color: :blue, disabled: true)) { "Disabled" }
+        button_component(color: :blue, disabled: true)) { "Disabled" }
       end
 
       def dark_disabled
-        render(InkComponents::Button::Component.new(color: :dark, disabled: true)) { "Disabled" }
+        button_component(color: :dark, disabled: true)) { "Disabled" }
       end
 
       def green_disabled
-        render(InkComponents::Button::Component.new(color: :green, disabled: true)) { "Disabled" }
+        button_component(color: :green, disabled: true)) { "Disabled" }
       end
 
       def red_disabled
-        render(InkComponents::Button::Component.new(color: :red, disabled: true)) { "Disabled" }
+        button_component(color: :red, disabled: true)) { "Disabled" }
       end
 
       def yellow_disabled
-        render(InkComponents::Button::Component.new(color: :yellow, disabled: true)) { "Disabled" }
+        button_component(color: :yellow, disabled: true)) { "Disabled" }
       end
 
       def purple_disabled
-        render(InkComponents::Button::Component.new(color: :purple, disabled: true)) { "Disabled" }
+        button_component(color: :purple, disabled: true)) { "Disabled" }
       end
       # @!endgroup
 
       # @!group Outline Disabled
       def pink_disabled_outline
-        render(InkComponents::Button::Component.new(shape: :outline, color: :pink, disabled: true)) { "Disabled" }
+        button_component(shape: :outline, color: :pink, disabled: true)) { "Disabled" }
       end
 
       def blue_disabled_outline
-        render(InkComponents::Button::Component.new(shape: :outline, color: :blue, disabled: true)) { "Disabled" }
+        button_component(shape: :outline, color: :blue, disabled: true)) { "Disabled" }
       end
 
       def dark_disabled_outline
-        render(InkComponents::Button::Component.new(shape: :outline, color: :dark, disabled: true)) { "Disabled" }
+        button_component(shape: :outline, color: :dark, disabled: true)) { "Disabled" }
       end
 
       def green_disabled_outline
-        render(InkComponents::Button::Component.new(shape: :outline, color: :green, disabled: true)) { "Disabled" }
+        button_component(shape: :outline, color: :green, disabled: true)) { "Disabled" }
       end
 
       def red_disabled_outline
-        render(InkComponents::Button::Component.new(shape: :outline, color: :red, disabled: true)) { "Disabled" }
+        button_component(shape: :outline, color: :red, disabled: true)) { "Disabled" }
       end
 
       def yellow_disabled_outline
-        render(InkComponents::Button::Component.new(shape: :outline, color: :yellow, disabled: true)) { "Disabled" }
+        button_component(shape: :outline, color: :yellow, disabled: true)) { "Disabled" }
       end
 
       def purple_disabled_outline
-        render(InkComponents::Button::Component.new(shape: :outline, color: :purple, disabled: true)) { "Disabled" }
+        button_component(shape: :outline, color: :purple, disabled: true)) { "Disabled" }
       end
       # @!endgroup
     end

--- a/app/components/ink_components/card/preview.rb
+++ b/app/components/ink_components/card/preview.rb
@@ -5,27 +5,27 @@ module InkComponents
     class Preview < Lookbook::Preview
       # @param orientation select { choices: [vertical, horizontal] }
       def playground(orientation: :vertical)
-        render InkComponents::Card::Component.new(orientation:) do
+        card_component(orientation:) do
           tag.p "Here are the biggest enterprise technology acquisitions of 2021 so far, in reverse chronological order.", class: "font-normal text-gray-700 dark:text-gray-400"
         end
       end
 
       # @!group Orientations
       def vertical_orientation
-        render InkComponents::Card::Component.new(orientation: :vertical) do
+        card_component(orientation: :vertical) do
           tag.p "Here are the biggest enterprise technology acquisitions of 2021 so far, in reverse chronological order.", class: "font-normal text-gray-700 dark:text-gray-400"
         end
       end
 
       def horizontal_orientation
-        render InkComponents::Card::Component.new(orientation: :horizontal) do
+        card_component(orientation: :horizontal) do
           tag.p "Here are the biggest enterprise technology acquisitions of 2021 so far, in reverse chronological order.", class: "font-normal text-gray-700 dark:text-gray-400"
         end
       end
       # @!endgroup
 
       def with_html_content
-        render InkComponents::Card::Component.new do
+        card_component do
           '<a href="#">
             <h5 class="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">Noteworthy technology acquisitions 2021</h5>
           </a>
@@ -40,7 +40,7 @@ module InkComponents
       end
 
       def with_html_form
-        render InkComponents::Card::Component.new do
+        card_component do
           '<form class="space-y-6" action="#">
             <h5 class="text-xl font-medium text-gray-900 dark:text-white">Sign in to our platform</h5>
             <div>

--- a/app/components/ink_components/forms/checkbox/preview.rb
+++ b/app/components/ink_components/forms/checkbox/preview.rb
@@ -3,7 +3,7 @@
 module InkComponents
   module Forms
     module Checkbox
-      class Preview < ViewComponent::Preview
+      class Preview < Lookbook::Preview
         # @param checked toggle
         # @param disabled toggle
         # @param bordered toggle
@@ -18,7 +18,7 @@ module InkComponents
           helper_text: nil,
           content: "Some value"
         )
-          render(InkComponents::Forms::Checkbox::Component.new(checked:, disabled:, bordered:, color:)) do |checkbox|
+          checkbox_component(checked:, disabled:, bordered:, color:) do |checkbox|
             checkbox.with_helper_text { helper_text } if helper_text.present?
             content
           end
@@ -26,55 +26,55 @@ module InkComponents
 
         # @!group Colors
         def blue
-          render(InkComponents::Forms::Checkbox::Component.new(color: :blue, checked: true)) { "Blue" }
+          checkbox_component(color: :blue, checked: true) { "Blue" }
         end
 
         def red
-          render(InkComponents::Forms::Checkbox::Component.new(color: :red, checked: true)) { "Red" }
+          checkbox_component(color: :red, checked: true) { "Red" }
         end
 
         def green
-          render(InkComponents::Forms::Checkbox::Component.new(color: :green, checked: true)) { "Green" }
+          checkbox_component(color: :green, checked: true) { "Green" }
         end
 
         def purple
-          render(InkComponents::Forms::Checkbox::Component.new(color: :purple, checked: true)) { "Purple" }
+          checkbox_component(color: :purple, checked: true) { "Purple" }
         end
 
         def teal
-          render(InkComponents::Forms::Checkbox::Component.new(color: :teal, checked: true)) { "Teal" }
+          checkbox_component(color: :teal, checked: true) { "Teal" }
         end
 
         def yellow
-          render(InkComponents::Forms::Checkbox::Component.new(color: :yellow, checked: true)) { "Yellow" }
+          checkbox_component(color: :yellow, checked: true) { "Yellow" }
         end
 
         def orange
-          render(InkComponents::Forms::Checkbox::Component.new(color: :orange, checked: true)) { "Orange" }
+          checkbox_component(color: :orange, checked: true) { "Orange" }
         end
         # @!endgroup
 
         # @!group With Html Attributes
         def disabled
-          render(InkComponents::Forms::Checkbox::Component.new(disabled: true)) { "Disabled" }
+          checkbox_component(disabled: true) { "Disabled" }
         end
 
         def disabled_checked
-          render(InkComponents::Forms::Checkbox::Component.new(checked: true, disabled: true)) { "Disabled" }
+          checkbox_component(checked: true, disabled: true) { "Disabled" }
         end
 
         def with_id_and_name
-          render(InkComponents::Forms::Checkbox::Component.new(id: "product", name: "product[some_value]")) { "Some value" }
+          checkbox_component(id: "product", name: "product[some_value]") { "Some value" }
         end
         # @!endgroup
 
         # @!group With Border
         def border
-          render(InkComponents::Forms::Checkbox::Component.new(bordered: true)) { "Some value" }
+          checkbox_component(bordered: true) { "Some value" }
         end
 
         def border_with_helper_text
-          render(InkComponents::Forms::Checkbox::Component.new(bordered: true)) do |checkbox|
+          checkbox_component(bordered: true) do |checkbox|
             checkbox.with_helper_text { "Some helper text" }
             "Another value"
           end
@@ -82,7 +82,7 @@ module InkComponents
         # @!endgroup
 
         def with_helper_text
-          render(InkComponents::Forms::Checkbox::Component.new(id: "product", name: "product[some_value]")) do |checkbox|
+          checkbox_component(id: "product", name: "product[some_value]") do |checkbox|
             checkbox.with_helper_text { "Some helper text" }
             "Some value"
           end

--- a/app/components/ink_components/forms/dropzone/preview.rb
+++ b/app/components/ink_components/forms/dropzone/preview.rb
@@ -5,7 +5,7 @@ module InkComponents
     module Dropzone
       class Preview < Lookbook::Preview
         def default
-          render InkComponents::Forms::Dropzone::Component.new(id: "input-file") do |dropzone|
+          dropzone_component(id: "input-file") do |dropzone|
             dropzone.with_label { "<p class='text-gray-500 dark:text-gray-400'><span class='font-semibold'>Click to upload</span> or drag and drop</p>".html_safe }
             dropzone.with_helper_text { "SVG, PNG, JPG or GIF (MAX. 800x400px)" }
           end

--- a/app/components/ink_components/forms/file_input/preview.rb
+++ b/app/components/ink_components/forms/file_input/preview.rb
@@ -6,31 +6,31 @@ module InkComponents
       class Preview < Lookbook::Preview
         # @param size select { choices: [xs, sm, lg] }
         def playground(size: :sm)
-          render InkComponents::Forms::FileInput::Component.new(size:)
+          file_input_component(size:)
         end
 
         # @!group Sizes
         def extra_small
-          render InkComponents::Forms::FileInput::Component.new(size: :xs)
+          file_input_component(size: :xs)
         end
 
         def small
-          render InkComponents::Forms::FileInput::Component.new(size: :sm)
+          file_input_component(size: :sm)
         end
 
         def large
-          render InkComponents::Forms::FileInput::Component.new(size: :lg)
+          file_input_component(size: :lg)
         end
         # @!endgroup
 
         def with_helper_text
-          render InkComponents::Forms::FileInput::Component.new do |input|
+          file_input_component do |input|
             input.with_helper_text { "SVG, PNG, JPG or GIF (MAX. 800x400px)." }
           end
         end
 
         def with_multiple_files
-          render InkComponents::Forms::FileInput::Component.new(multiple: true)
+          file_input_component(multiple: true)
         end
       end
     end

--- a/app/components/ink_components/forms/helper_text/preview.rb
+++ b/app/components/ink_components/forms/helper_text/preview.rb
@@ -8,40 +8,30 @@ module InkComponents
         # @param size select { choices: [xs, sm] }
         # @param state select { choices: [default, success, error] }
         def playground(content: "Some text", size: :sm, state: :default)
-          render InkComponents::Forms::HelperText::Component.new(size:, state:).with_content(content)
+          helper_text_component(size:, state:) { content }
         end
 
         # @!group Sizes
         def extra_small
-          render InkComponents::Forms::HelperText::Component.new(size: :xs).with_content(
-            "We'll never share your details. Read our Privacy Policy."
-          )
+          helper_text_component(size: :xs) { "We'll never share your details. Read our Privacy Policy." }
         end
 
         def small
-          render InkComponents::Forms::HelperText::Component.new(size: :sm).with_content(
-            "We'll never share your details. Read our Privacy Policy."
-          )
+          helper_text_component(size: :sm) { "We'll never share your details. Read our Privacy Policy." }
         end
         # @!endgroup
 
         # @!group States
         def default
-          render InkComponents::Forms::HelperText::Component.new(state: :default).with_content(
-            "We'll never share your details. Read our Privacy Policy."
-          )
+          helper_text_component(state: :default) { "We'll never share your details. Read our Privacy Policy." }
         end
 
         def success
-          render InkComponents::Forms::HelperText::Component.new(state: :success).with_content(
-            "Well done! Some success message."
-          )
+          helper_text_component(state: :success) { "Well done! Some success message." }
         end
 
         def error
-          render InkComponents::Forms::HelperText::Component.new(state: :error).with_content(
-            "Oh, snapp! Some error message."
-          )
+          helper_text_component(state: :error) { "Oh, snapp! Some error message." }
         end
         # @!endgroup
       end

--- a/app/components/ink_components/forms/label/preview.rb
+++ b/app/components/ink_components/forms/label/preview.rb
@@ -7,11 +7,11 @@ module InkComponents
         # @param content text
         # @param state select { choices: [default, success, error] }
         def default(content: "Your name", state: :default)
-          render InkComponents::Forms::Label::Component.new(state:).with_content(content)
+          label_component(state:) { content }
         end
 
         def with_html_attributes
-          render InkComponents::Forms::Label::Component.new(id: "name").with_content("Your name")
+          label_component(id: "name") { "Your name" }
         end
       end
     end

--- a/app/components/ink_components/forms/radio/preview.rb
+++ b/app/components/ink_components/forms/radio/preview.rb
@@ -11,7 +11,7 @@ module InkComponents
         # @param bordered select { choices: [true, false] }
         # @param helper_text text
         def playground(content: "Some text", color: :pink, checked: false, disabled: false, bordered: false, helper_text: nil)
-          render InkComponents::Forms::Radio::Component.new(id: "default-radio-1", name: "name-radio", value: "value-1", color:, checked:, disabled:, bordered:) do |radio|
+          radio_component(id: "default-radio-1", name: "name-radio", value: "value-1", color:, checked:, disabled:, bordered:) do |radio|
             radio.with_helper_text { helper_text }
             content
           end
@@ -19,48 +19,48 @@ module InkComponents
 
         # @!group Colors
         def pink
-          render InkComponents::Forms::Radio::Component.new(id: "default-radio-1", name: "name-radio-1", value: "value-1", color: :pink, checked: true).with_content("Pink")
+          radio_component(id: "default-radio-1", name: "name-radio-1", value: "value-1", color: :pink, checked: true) { "Pink" }
         end
 
         def blue
-          render InkComponents::Forms::Radio::Component.new(id: "default-radio-2", name: "name-radio-2", value: "value-2", color: :blue, checked: true).with_content("Blue")
+          radio_component(id: "default-radio-2", name: "name-radio-2", value: "value-2", color: :blue, checked: true) { "Blue" }
         end
 
         def red
-          render InkComponents::Forms::Radio::Component.new(id: "default-radio-3", name: "name-radio-3", value: "value-3", color: :red, checked: true).with_content("Red")
+          radio_component(id: "default-radio-3", name: "name-radio-3", value: "value-3", color: :red, checked: true) { "Red" }
         end
 
         def green
-          render InkComponents::Forms::Radio::Component.new(id: "default-radio-4", name: "name-radio-4", value: "value-4", color: :green, checked: true).with_content("Green")
+          radio_component(id: "default-radio-4", name: "name-radio-4", value: "value-4", color: :green, checked: true) { "Green" }
         end
 
         def teal
-          render InkComponents::Forms::Radio::Component.new(id: "default-radio-5", name: "name-radio-5", value: "value-5", color: :teal, checked: true).with_content("Teal")
+          radio_component(id: "default-radio-5", name: "name-radio-5", value: "value-5", color: :teal, checked: true) { "Teal" }
         end
 
         def purple
-          render InkComponents::Forms::Radio::Component.new(id: "default-radio-6", name: "name-radio-6", value: "value-6", color: :purple, checked: true).with_content("Purple")
+          radio_component(id: "default-radio-6", name: "name-radio-6", value: "value-6", color: :purple, checked: true) { "Purple" }
         end
 
         def yellow
-          render InkComponents::Forms::Radio::Component.new(id: "default-radio-7", name: "name-radio-7", value: "value-7", color: :yellow, checked: true).with_content("Yellow")
+          radio_component(id: "default-radio-7", name: "name-radio-7", value: "value-7", color: :yellow, checked: true) { "Yellow" }
         end
 
         def orange
-          render InkComponents::Forms::Radio::Component.new(id: "default-radio-8", name: "name-radio-8", value: "value-8", color: :orange, checked: true).with_content("Orange")
+          radio_component(id: "default-radio-8", name: "name-radio-8", value: "value-8", color: :orange, checked: true) { "Orange" }
         end
         # @!endgroup
 
         def disabled
-          render InkComponents::Forms::Radio::Component.new(id: "default-radio-9", name: "name-radio-9", value: "value-9", disabled: true).with_content("Disabled")
+          radio_component(id: "default-radio-9", name: "name-radio-9", value: "value-9", disabled: true) { "Disabled" }
         end
 
         def bordered
-          render InkComponents::Forms::Radio::Component.new(id: "default-radio-10", name: "name-radio-10", value: "value-10", bordered: true).with_content("Bordered")
+          radio_component(id: "default-radio-10", name: "name-radio-10", value: "value-10", bordered: true) { "Bordered" }
         end
 
         def with_help_text
-          render InkComponents::Forms::Radio::Component.new(id: "default-radio-11", name: "name-radio-11", value: "value-11") do |radio|
+          radio_component(id: "default-radio-11", name: "name-radio-11", value: "value-11") do |radio|
             radio.with_helper_text { "For orders shipped from $25 in books or $29 in other categories" }
             "Free shipping via Flowbite"
           end

--- a/app/components/ink_components/forms/select/preview.rb
+++ b/app/components/ink_components/forms/select/preview.rb
@@ -9,82 +9,82 @@ module InkComponents
         # @param state select { choices: [default, success, error] }
         # @param disabled toggle
         def playground(state: :default, size: :md, prompt: "Selecione", disabled: false)
-          render InkComponents::Forms::Select::Component.new(state:, size:, prompt:, disabled:, options: DEFAULT_OPTIONS)
+          select_component(state:, size:, prompt:, disabled:, options: DEFAULT_OPTIONS)
         end
 
         # @!group Html Attributes
         def with_prompt
-          render InkComponents::Forms::Select::Component.new(prompt: "Selecione uma cor", options: DEFAULT_OPTIONS)
+          select_component(prompt: "Selecione uma cor", options: DEFAULT_OPTIONS)
         end
 
         def with_selected_option
-          render InkComponents::Forms::Select::Component.new(selected: "Green", options: DEFAULT_OPTIONS)
+          select_component(selected: "Green", options: DEFAULT_OPTIONS)
         end
 
         def with_multiple_options
-          render InkComponents::Forms::Select::Component.new(multiple: true, options: DEFAULT_OPTIONS)
+          select_component(multiple: true, options: DEFAULT_OPTIONS)
         end
 
         def with_html_attributes
-          render InkComponents::Forms::Select::Component.new(id: "color", name: "color", options: DEFAULT_OPTIONS)
+          select_component(id: "color", name: "color", options: DEFAULT_OPTIONS)
         end
         # @!endgroup
 
         # @!group States
         def default
-          render InkComponents::Forms::Select::Component.new(state: :default, options: DEFAULT_OPTIONS)
+          select_component(state: :default, options: DEFAULT_OPTIONS)
         end
 
         def success
-          render InkComponents::Forms::Select::Component.new(state: :success, options: DEFAULT_OPTIONS)
+          select_component(state: :success, options: DEFAULT_OPTIONS)
         end
 
         def error
-          render InkComponents::Forms::Select::Component.new(state: :error, options: DEFAULT_OPTIONS)
+          select_component(state: :error, options: DEFAULT_OPTIONS)
         end
 
         def disabled
-          render InkComponents::Forms::Select::Component.new(options: DEFAULT_OPTIONS, disabled: true)
+          select_component(options: DEFAULT_OPTIONS, disabled: true)
         end
         # @!endgroup
 
         # @!group Sizes
         def small
-          render InkComponents::Forms::Select::Component.new(size: :sm, options: DEFAULT_OPTIONS)
+          select_component(size: :sm, options: DEFAULT_OPTIONS)
         end
 
         def medium
-          render InkComponents::Forms::Select::Component.new(size: :md, options: DEFAULT_OPTIONS)
+          select_component(size: :md, options: DEFAULT_OPTIONS)
         end
 
         def large
-          render InkComponents::Forms::Select::Component.new(size: :lg, options: DEFAULT_OPTIONS)
+          select_component(size: :lg, options: DEFAULT_OPTIONS)
         end
         # @!endgroup
 
         # @!group Underline
         def default
-          render InkComponents::Forms::Select::Component.new(underline: true, options: DEFAULT_OPTIONS)
+          select_component(underline: true, options: DEFAULT_OPTIONS)
         end
 
         def small_size
-          render InkComponents::Forms::Select::Component.new(underline: true, size: :sm, options: DEFAULT_OPTIONS)
+          select_component(underline: true, size: :sm, options: DEFAULT_OPTIONS)
         end
 
         def medium_size
-          render InkComponents::Forms::Select::Component.new(underline: true, size: :md, options: DEFAULT_OPTIONS)
+          select_component(underline: true, size: :md, options: DEFAULT_OPTIONS)
         end
 
         def large_size
-          render InkComponents::Forms::Select::Component.new(underline: true, size: :lg, options: DEFAULT_OPTIONS)
+          select_component(underline: true, size: :lg, options: DEFAULT_OPTIONS)
         end
 
         def success_state
-          render InkComponents::Forms::Select::Component.new(underline: true, state: :success, options: DEFAULT_OPTIONS)
+          select_component(underline: true, state: :success, options: DEFAULT_OPTIONS)
         end
 
         def error_state
-          render InkComponents::Forms::Select::Component.new(underline: true, state: :error, options: DEFAULT_OPTIONS)
+          select_component(underline: true, state: :error, options: DEFAULT_OPTIONS)
         end
         # @!endgroup
       end

--- a/app/components/ink_components/forms/text_area/preview.rb
+++ b/app/components/ink_components/forms/text_area/preview.rb
@@ -9,7 +9,7 @@ module InkComponents
         # @param rows number
         # @param cols number
         def playground(placeholder: "Write your thoughts here...", value: nil, rows: nil, cols: nil)
-          render InkComponents::Forms::TextArea::Component.new(placeholder:, value:, rows:, cols:)
+          text_area_component(placeholder:, value:, rows:, cols:)
         end
       end
     end

--- a/app/components/ink_components/forms/toggle/preview.rb
+++ b/app/components/ink_components/forms/toggle/preview.rb
@@ -10,68 +10,68 @@ module InkComponents
         # @param disabled toggle
         # @param checked toggle
         def playground(content: "Some Text", size: :md, color: :pink, disabled: false, checked: false)
-          render InkComponents::Forms::Toggle::Component.new(size:, color:, disabled:, checked:).with_content(content)
+          toggle_component(size:, color:, disabled:, checked:) { content }
         end
 
         def checked_state
-          render InkComponents::Forms::Toggle::Component.new(size: :md, color: :pink, checked: true).with_content("Checked toggle")
+          toggle_component(size: :md, color: :pink, checked: true) { "Checked toggle" }
         end
 
         # @!group Disabled
         def disabled_toggle
-          render InkComponents::Forms::Toggle::Component.new(size: :md, color: :pink, disabled: true, checked: false).with_content("Disabled toggle")
+          toggle_component(size: :md, color: :pink, disabled: true, checked: false) { "Disabled toggle" }
         end
 
         def disabled_checked
-          render InkComponents::Forms::Toggle::Component.new(size: :md, color: :pink, disabled: true, checked: true).with_content("Disabled checked toggle")
+          toggle_component(size: :md, color: :pink, disabled: true, checked: true) { "Disabled checked toggle" }
         end
         # @!endgroup
 
         # @!group Colors
         def pink
-          render InkComponents::Forms::Toggle::Component.new(size: :md, color: :pink, checked: true)
+          toggle_component(size: :md, color: :pink, checked: true)
         end
 
         def blue
-          render InkComponents::Forms::Toggle::Component.new(size: :md, color: :blue, checked: true)
+          toggle_component(size: :md, color: :blue, checked: true)
         end
 
         def red
-          render InkComponents::Forms::Toggle::Component.new(size: :md, color: :red, checked: true)
+          toggle_component(size: :md, color: :red, checked: true)
         end
 
         def green
-          render InkComponents::Forms::Toggle::Component.new(size: :md, color: :green, checked: true)
+          toggle_component(size: :md, color: :green, checked: true)
         end
 
         def purple
-          render InkComponents::Forms::Toggle::Component.new(size: :md, color: :purple, checked: true)
+          toggle_component(size: :md, color: :purple, checked: true)
         end
 
         def yellow
-          render InkComponents::Forms::Toggle::Component.new(size: :md, color: :yellow, checked: true)
+          toggle_component(size: :md, color: :yellow, checked: true)
         end
 
         def teal
-          render InkComponents::Forms::Toggle::Component.new(size: :md, color: :teal, checked: true)
+          toggle_component(size: :md, color: :teal, checked: true)
         end
 
         def orange
-          render InkComponents::Forms::Toggle::Component.new(size: :md, color: :orange, checked: true)
+          toggle_component(size: :md, color: :orange, checked: true)
         end
         # @!endgroup
 
         # @!group Sizes
         def small
-          render InkComponents::Forms::Toggle::Component.new(size: :sm, color: :pink)
+          toggle_component(size: :sm, color: :pink)
         end
 
         def medium
-          render InkComponents::Forms::Toggle::Component.new(size: :md, color: :pink)
+          toggle_component(size: :md, color: :pink)
         end
 
         def large
-          render InkComponents::Forms::Toggle::Component.new(size: :lg, color: :pink)
+          toggle_component(size: :lg, color: :pink)
         end
         # @!endgroup
       end

--- a/app/components/ink_components/icon/preview.rb
+++ b/app/components/ink_components/icon/preview.rb
@@ -4,12 +4,12 @@ module InkComponents
       # @!group Types
       # @param name select :icon_names "The icon name"
       def with_solid_type(name: :bell)
-        render InkComponents::Icon::Component.new(name:, class: "w-6 h-6 fill-gray-500")
+        icon_component(name:, class: "w-6 h-6 fill-gray-500")
       end
 
       # @param name select :icon_names "The icon name"
       def with_outline_type(name: :bell)
-        render InkComponents::Icon::Component.new(name:, type: :outline, class: "w-6 h-6 text-gray-500")
+        icon_component(name:, type: :outline, class: "w-6 h-6 text-gray-500")
       end
       # @!endgroup
 

--- a/app/components/ink_components/progress_bar/preview.rb
+++ b/app/components/ink_components/progress_bar/preview.rb
@@ -9,65 +9,65 @@ module InkComponents
       # @param size select { choices: [sm, md, lg, xl] }
       # @param color select { choices: [pink, dark, blue, red, green, yellow, indigo, purple] }
       def playground(size: :md, color: :pink, progress: 45, progress_position: :inside, content: nil)
-        render(InkComponents::ProgressBar::Component.new(size:, color:, progress:, progress_position:)) { content }
+        progress_bar_component(size:, color:, progress:, progress_position:) { content }
       end
 
       # @!group Sizes
       def small
-        render InkComponents::ProgressBar::Component.new(size: :sm, progress: 45)
+        progress_bar_component(size: :sm, progress: 45)
       end
 
       def medium
-        render InkComponents::ProgressBar::Component.new(size: :md, progress: 45)
+        progress_bar_component(size: :md, progress: 45)
       end
 
       def large
-        render InkComponents::ProgressBar::Component.new(size: :lg, progress: 45)
+        progress_bar_component(size: :lg, progress: 45)
       end
 
       def extra_large
-        render InkComponents::ProgressBar::Component.new(size: :xl, progress: 45)
+        progress_bar_component(size: :xl, progress: 45)
       end
       # @!endgroup
 
       # @!group Colors
       def dark
-        render InkComponents::ProgressBar::Component.new(color: :dark, progress: 45)
+        progress_bar_component(color: :dark, progress: 45)
       end
 
       def blue
-        render InkComponents::ProgressBar::Component.new(color: :blue, progress: 45)
+        progress_bar_component(color: :blue, progress: 45)
       end
 
       def red
-        render InkComponents::ProgressBar::Component.new(color: :red, progress: 45)
+        progress_bar_component(color: :red, progress: 45)
       end
 
       def green
-        render InkComponents::ProgressBar::Component.new(color: :green, progress: 45)
+        progress_bar_component(color: :green, progress: 45)
       end
 
       def yellow
-        render InkComponents::ProgressBar::Component.new(color: :yellow, progress: 45)
+        progress_bar_component(color: :yellow, progress: 45)
       end
 
       def indigo
-        render InkComponents::ProgressBar::Component.new(color: :indigo, progress: 45)
+        progress_bar_component(color: :indigo, progress: 45)
       end
 
       def purple
-        render InkComponents::ProgressBar::Component.new(color: :purple, progress: 45)
+        progress_bar_component(color: :purple, progress: 45)
       end
       # @!endgroup
 
       # @!group Progress Positions
       # @label Inside (In this option, the progress bar size remains fixed)
       def inside
-        render InkComponents::ProgressBar::Component.new(progress_position: :inside, progress: 45)
+        progress_bar_component(progress_position: :inside, progress: 45)
       end
 
       def top
-        render(InkComponents::ProgressBar::Component.new(progress_position: :top, progress: 45)) { "Progress" }
+        progress_bar_component(progress_position: :top, progress: 45) { "Progress" }
       end
       # @!endgroup
     end


### PR DESCRIPTION
No [PR](https://github.com/rsv-ink/ink_components/pull/80/files) foram adicionados helpers para facilitar o consumo dos componentes, no entanto, apenas para no preview do component alert está sendo utilizado esse helper. Nessa atividade, os previews dos demais componentes serão atualizados com as chamadas dos métods_helpers.