### PR TITLE
feat: Cria helper radio_button para o Form Builder

### DIFF
--- a/app/helpers/ink_components/form_builder.rb
+++ b/app/helpers/ink_components/form_builder.rb
@@ -17,7 +17,7 @@ module InkComponents
     def radio_button(attribute, value, content = nil, **)
       checked = object.try(:public_send, attribute) == value
 
-      radio_component(id: format_id(attribute, value), name: format_name(attribute), value:, checked:) { content }
+      radio_component(id: format_id(attribute, value), name: format_name(attribute), value:, checked:, **) { content }
     end
 
     def check_box(attribute, options = {}, checked_value = "1", unchecked_value = "0")

--- a/app/helpers/ink_components/form_builder.rb
+++ b/app/helpers/ink_components/form_builder.rb
@@ -14,6 +14,12 @@ module InkComponents
       label_component(for: format_id(attribute), **) { content }
     end
 
+    def radio_button(attribute, value, content = nil, **)
+      checked = object.try(:public_send, attribute) == value
+
+      radio_component(id: format_id(attribute, value), name: format_name(attribute), value:, checked:) { content }
+    end
+
     def check_box(attribute, options = {}, checked_value = "1", unchecked_value = "0")
       checked = object.try(:public_send, attribute).in?([ true, checked_value ])
 
@@ -61,10 +67,11 @@ module InkComponents
       }
     end
 
-    def format_id(attribute)
-      resource_name = object_name.present? ? object_name+"_" : ""
+    def format_id(attribute, value = nil)
+      resource_name = "#{object_name}_" if object_name.present?
+      tag_value = "_#{value}" if value.present?
 
-      "#{resource_name}#{attribute}".delete("]").tr("^-a-zA-Z0-9:.", "_")
+      "#{resource_name}#{attribute}#{tag_value}".delete("]").tr("^-a-zA-Z0-9:.", "_")
     end
 
     def format_name(attribute)

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,6 +2,48 @@
 
 <br><br>
 
+<h1>Sem form builder:</h1>
+
+<%= form_with model: @user do |f| %>
+  <%= f.label :name, data: { controller: "test" } %>
+  <%= f.text_field :name %>
+
+  <br><br>
+
+  <%= f.label :email %>
+  <%= f.text_field :email %>
+
+
+  <br><br>
+
+  <div class="flex">
+    <%= f.check_box :paid %>
+    <%= f.label :paid, class: "mb-0" %>
+  </div>
+
+  <br>
+  <div>
+    <div>
+      <%= f.radio_button :type, :admin %>
+      <%= f.label :type_admin %>
+    </div>
+    <div>
+      <%= f.radio_button :type, :tester %>
+      <%= f.label :type_tester %>
+    </div>
+    <div>
+      <%= f.radio_button :type, :guest_user %>
+      <%= f.label :type_guest_user %>
+    </div>
+  </div>
+
+  <%= f.submit %>
+<% end %>
+
+<br><br>
+
+<h1>Com form builder</h1>
+
 <%= form_with model: @user, builder: InkComponents::FormBuilder do |f| %>
   <%= f.label :name, data: { controller: "test" } %>
   <%= f.text_field :name %>
@@ -15,9 +57,24 @@
 
   <br><br>
 
-  <div class="flex">
+  <div class="flex mb-4">
     <%= f.check_box :paid %>
     <%= f.label :paid, class: "mb-0" %>
+  </div>
+
+  <div>
+    <div class="flex mb-2">
+      <%= f.radio_button :color, :blue %>
+      <%= f.label :color_blue, class: "mb-0" %>
+    </div>
+    <div class="flex mb-2">
+      <%= f.radio_button :color, :pink %>
+      <%= f.label :color_pink, class: "mb-0" %>
+    </div>
+    <div class="flex mb-2">
+      <%= f.radio_button :color, :gray %>
+      <%= f.label :color_gray, class: "mb-0" %>
+    </div>
   </div>
 
   <%= f.submit %>

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@
 
 class UsersController < ApplicationController
   def new
-    @user = User.new(name: "", email: "", paid: true)
+    @user = User.new(name: "", email: "", paid: true, type: "", color: "")
   end
 
   def create
@@ -16,6 +16,6 @@ class UsersController < ApplicationController
   def user_params
     return {} unless params.key?(:user)
 
-    params.require(:user).permit(:name, :email, :paid)
+    params.require(:user).permit(:name, :email, :paid, :type, :color)
   end
 end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -7,13 +7,15 @@ class User
   validates :name, length: { minimum: 3 }
   validates :name, format: { with: /\A[a-zA-Z]+\z/, message: "only allows letters" }
 
-  attr_accessor :name, :email, :paid
+  attr_accessor :name, :email, :paid, :type, :color
 
   def initialize(**kwargs)
     super
     @paid = kwargs.fetch("paid", false)
     @name = kwargs.fetch("name", "")
     @email = kwargs.fetch("email", "")
+    @type = kwargs.fetch("type", "")
+    @color = kwargs.fetch("color", "")
   end
 
   def persisted?


### PR DESCRIPTION
 O helper `radio_button` gera uma tag de botão de rádio que permite acessar um atributo específico de um objeto atribuído ao template. Caso o valor atual do método corresponda a `value`, o botão de rádio será marcado. Esse helper está em conformidade com a interface do Rails.

Exemplo:
```ruby
# Se @article.category retorna "rails"
radio_button("article", "category", "rails") # esse radio será marcado
radio_button("article", "category", "java")
# => <input type="radio" id="article_category_rails" name="article[category]" value="rails" checked="checked" />
# => <input type="radio" id="article_category_java" name="article[category]" value="java" />
```

## Referências
https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-radio_button

