### PR TITLE
feat: Cria helper select para Form Builder

### DIFF
--- a/app/helpers/ink_components/form_builder.rb
+++ b/app/helpers/ink_components/form_builder.rb
@@ -28,6 +28,18 @@ module InkComponents
       )
     end
 
+    def select(attribute, choices = nil, select_options = {}, tag_options = {})
+      html_options = html_options(attribute)
+      select_component(
+        state: field_state(attribute),
+        options: choices,
+        selected: html_options[:value],
+        **select_options,
+        **tag_options,
+        **html_options,
+      )
+    end
+
     def text_field(attribute, **)
       state = field_state(attribute)
       input_field_component(type: :text, state:, **html_options(attribute), **)

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -13,7 +13,6 @@
   <%= f.label :email %>
   <%= f.text_field :email %>
 
-
   <br><br>
 
   <div class="flex">
@@ -22,26 +21,6 @@
   </div>
 
   <br>
-  <div>
-    <div>
-      <%= f.radio_button :type, :admin %>
-      <%= f.label :type_admin %>
-    </div>
-    <div>
-      <%= f.radio_button :type, :tester %>
-      <%= f.label :type_tester %>
-    </div>
-    <div>
-      <%= f.radio_button :type, :guest_user %>
-      <%= f.label :type_guest_user %>
-    </div>
-  </div>
-
-  <%= f.select :color,
-    [["Blue", "blue"], ["Pink", "pink"], ["Green", "green"]],
-    { prompt: "Selecione", include_blank: false },
-    { class: "mt-4" }
-  %>
 
   <%= f.submit %>
 <% end %>
@@ -60,36 +39,12 @@
   <%= f.label :email %>
   <%= f.text_field :email %>
 
-
   <br><br>
 
   <div class="flex mb-4">
     <%= f.check_box :paid %>
     <%= f.label :paid, class: "mb-0" %>
   </div>
-
-  <div>
-    <div class="flex mb-2">
-      <%= f.radio_button :color, :blue %>
-      <%= f.label :color_blue, class: "mb-0" %>
-    </div>
-    <div class="flex mb-2">
-      <%= f.radio_button :color, :pink %>
-      <%= f.label :color_pink, class: "mb-0" %>
-    </div>
-    <div class="flex mb-2">
-      <%= f.radio_button :color, :gray %>
-      <%= f.label :color_gray, class: "mb-0" %>
-    </div>
-  </div>
-
-  <br>
-
-  <%= f.select :color,
-    [["Blue", "blue"], ["Pink", "pink"], ["Green", "green"]],
-    { prompt: "Selecione", include_blank: false },
-    { class: "mb-4" }
-  %>
 
   <%= f.submit %>
 <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -37,6 +37,12 @@
     </div>
   </div>
 
+  <%= f.select :color,
+    [["Blue", "blue"], ["Pink", "pink"], ["Green", "green"]],
+    { prompt: "Selecione", include_blank: false },
+    { class: "mt-4" }
+  %>
+
   <%= f.submit %>
 <% end %>
 
@@ -76,6 +82,14 @@
       <%= f.label :color_gray, class: "mb-0" %>
     </div>
   </div>
+
+  <br>
+
+  <%= f.select :color,
+    [["Blue", "blue"], ["Pink", "pink"], ["Green", "green"]],
+    { prompt: "Selecione", include_blank: false },
+    { class: "mb-4" }
+  %>
 
   <%= f.submit %>
 <% end %>


### PR DESCRIPTION
Implementei o helper `select` para simplificar a utilização do componente em formulários. Esse método mantém a mesma interface do Rails, facilitando a transição para o Form Builder. Ele aceita os seguintes parâmetros:

- `attribute`: representa o atributo do modelo.
-  `choices`: lista de opções disponíveis para seleção, equivalente a `options` no componente.
- `select_options`: configurações específicas para campos select, como `prompt` e `include_blank`.
- `tag_options`: opções HTML adicionais, como `data_attributes` e `class`, correspondendo a `extra_attributes` no componente.

Obs: O helper `select` do Rails tem a possibilidade de receber um bloco, esse comportamento será implementado em nosso componente em uma próxima atividade.

## Referências
https://apidock.com/rails/ActionView/Helpers/FormOptionsHelper/select