### PR TITLE
feat: Adiciona helper number_field ao Form Builder

### DIFF
--- a/app/helpers/ink_components/form_builder.rb
+++ b/app/helpers/ink_components/form_builder.rb
@@ -33,6 +33,12 @@ module InkComponents
       input_field_component(type: :text, state:, **html_options(attribute), **)
     end
 
+
+    def number_field(attribute, **)
+      state = field_state(attribute)
+      input_field_component(type: :number, state:, **html_options(attribute), **)
+    end
+
     def error_message(attribute, **)
       state = field_state(attribute)
       helper_text_component(state:, **) { error_messages(attribute) }

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -13,13 +13,17 @@
   <%= f.label :email %>
   <%= f.text_field :email %>
 
-
   <br><br>
 
   <div class="flex">
     <%= f.check_box :paid %>
     <%= f.label :paid, class: "mb-0" %>
   </div>
+
+  <br><br>
+
+  <%= f.label :age %>
+  <%= f.number_field :age, min: 10 %>
 
   <br>
   <div>
@@ -54,6 +58,12 @@
   <%= f.label :email %>
   <%= f.text_field :email %>
 
+
+  <br><br>
+
+  <%= f.label :age %>
+  <%= f.number_field :age, value:2, step: 3 %>
+  <%= f.error_message :age %>
 
   <br><br>
 

--- a/spec/dummy/app/controllers/users_controller.rb
+++ b/spec/dummy/app/controllers/users_controller.rb
@@ -16,6 +16,6 @@ class UsersController < ApplicationController
   def user_params
     return {} unless params.key?(:user)
 
-    params.require(:user).permit(:name, :email, :paid, :type, :color)
+    params.require(:user).permit(:name, :email, :paid, :type, :color, :age)
   end
 end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -6,8 +6,9 @@ class User
   validates :name, presence: true
   validates :name, length: { minimum: 3 }
   validates :name, format: { with: /\A[a-zA-Z]+\z/, message: "only allows letters" }
+  validates :age, numericality: { greater_than: 18, message: "must be greater than 18" }
 
-  attr_accessor :name, :email, :paid, :type, :color
+  attr_accessor :name, :email, :paid, :type, :color, :age
 
   def initialize(**kwargs)
     super
@@ -16,6 +17,7 @@ class User
     @email = kwargs.fetch("email", "")
     @type = kwargs.fetch("type", "")
     @color = kwargs.fetch("color", "")
+    @age = kwargs.fetch("age", 1)
   end
 
   def persisted?


### PR DESCRIPTION
Implementei o helper number_fiel para simplificar a utilização do componente em formulários. Esse método mantém a mesma interface do Rails, facilitando a transição para o Form Builder. Ele aceita os seguintes parâmetros:
