### PR TITLE
feat: Cria helper submit para Form Builder

### DIFF
--- a/app/helpers/ink_components/form_builder.rb
+++ b/app/helpers/ink_components/form_builder.rb
@@ -51,7 +51,7 @@ module InkComponents
     end
 
     def submit(content = nil, **)
-      content ||= submit_text
+      content ||= submit_default_value
       button_component(builder: :button_tag, value: content, data: { disable_with: content }, **) { content }
     end
 
@@ -62,13 +62,6 @@ module InkComponents
       else
         I18n.t("helpers.label.#{attribute}", default: attribute.to_s.humanize)
       end
-    end
-
-    def submit_text
-      return "Submit" if object.nil?
-
-      submit_key = object.new_record? ? "helpers.submit.create" : "helpers.submit.update"
-      I18n.t(submit_key, model: object.model_name.human)
     end
 
     def field_state(attribute)

--- a/app/helpers/ink_components/form_builder.rb
+++ b/app/helpers/ink_components/form_builder.rb
@@ -50,6 +50,11 @@ module InkComponents
       helper_text_component(state:, **) { error_messages(attribute) }
     end
 
+    def submit(content = nil, **)
+      content ||= submit_text
+      button_component(builder: :button_tag, value: content, data: { disable_with: content }, **) { content }
+    end
+
     private
     def label_text(attribute)
       content ||= if object_name.present?
@@ -57,6 +62,13 @@ module InkComponents
       else
         I18n.t("helpers.label.#{attribute}", default: attribute.to_s.humanize)
       end
+    end
+
+    def submit_text
+      return "Submit" if object.nil?
+
+      submit_key = object.new_record? ? "helpers.submit.create" : "helpers.submit.update"
+      I18n.t(submit_key, model: object.model_name.human)
     end
 
     def field_state(attribute)

--- a/app/helpers/ink_components/form_builder.rb
+++ b/app/helpers/ink_components/form_builder.rb
@@ -50,9 +50,10 @@ module InkComponents
       helper_text_component(state:, **) { error_messages(attribute) }
     end
 
-    def submit(content = nil, **)
+    def submit(content = nil, **options)
       content ||= submit_default_value
-      button_component(builder: :button_tag, value: content, data: { disable_with: content }, **) { content }
+      options[:data] = { disable_with: content }.merge(options[:data] || {})
+      button_component(builder: :button_tag, value: content, **options) { content }
     end
 
     private

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -21,4 +21,8 @@ class User
   def persisted?
     false
   end
+
+  def new_record?
+    true
+  end
 end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -21,8 +21,4 @@ class User
   def persisted?
     false
   end
-
-  def new_record?
-    true
-  end
 end


### PR DESCRIPTION
Implementei o helper `submit` para renderizar um componente de botão personalizado, especificamente destinado à submissão de formulários. Este método preserva a mesma interface do Rails, o que facilita a transição para o Form Builder. Ele aceita os seguintes parâmetros:

-  `content`: O texto ou conteúdo a ser exibido no botão.
-  `kwargs`: Permite a inclusão de quaisquer atributos HTML, além de parâmetros específicos do componente, como `size: :sm`.

## Referências
https://apidock.com/rails/v7.1.3.4/ActionView/Helpers/FormBuilder/submit