### PR TITLE
feat: Adiciona estado ao componente text area

### DIFF
--- a/app/components/ink_components/forms/text_area/component.rb
+++ b/app/components/ink_components/forms/text_area/component.rb
@@ -6,21 +6,44 @@ module InkComponents
       class Component < ApplicationComponent
         style do
           base {
-            %w[
-              block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300
-              focus:ring-pink-500 focus:border-pink-500 dark:bg-gray-700 dark:border-gray-600
-              dark:placeholder-gray-400 dark:text-white dark:focus:ring-pink-500 dark:focus:border-pink-500
-            ]
+            %w[ block p-2.5 w-full text-sm rounded-lg border dark:bg-gray-700 ]
           }
+          variants {
+            state {
+              default {
+                %w[
+                  bg-gray-50 border-gray-300 text-gray-900 focus:ring-pink-500 focus:border-pink-500
+                  dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-pink-500
+                  dark:focus:border-pink-500
+                ]
+              }
+              success {
+                %w[
+                  bg-green-50 border-green-500 text-green-900 dark:text-green-400 placeholder-green-700
+                  dark:placeholder-green-500 focus:ring-green-500 focus:border-green-500 dark:border-green-500
+                ]
+              }
+              error {
+                %w[
+                  bg-red-50 border-red-500 text-red-900 placeholder-red-700 focus:ring-red-500
+                  focus:border-red-500 dark:text-red-500 dark:placeholder-red-500 dark:border-red-500
+                ]
+              }
+            }
+          }
+          defaults { { state: :default } }
         end
 
-        def initialize(**extra_attributes)
+        attr_reader :state
+
+        def initialize(state: :default, **extra_attributes)
+          @state = state
           super(**extra_attributes)
         end
 
         private
         def default_attributes
-          { class: style }
+          { class: style(state:) }
         end
       end
     end

--- a/app/components/ink_components/forms/text_area/preview.rb
+++ b/app/components/ink_components/forms/text_area/preview.rb
@@ -5,12 +5,27 @@ module InkComponents
     module TextArea
       class Preview < Lookbook::Preview
         # @param placeholder text
+        # @param state select { choices: [default, success, error] }
         # @param value text
         # @param rows number
         # @param cols number
-        def playground(placeholder: "Write your thoughts here...", value: nil, rows: nil, cols: nil)
-          text_area_component(placeholder:, value:, rows:, cols:)
+        def playground(placeholder: "Write your thoughts here...", value: nil, rows: nil, cols: nil, state: nil)
+          text_area_component(placeholder:, value:, rows:, cols:, state:)
         end
+
+        # @!group States
+        def default
+          text_area_component
+        end
+
+        def success
+          text_area_component(state: :success)
+        end
+
+        def error
+          text_area_component(state: :error)
+        end
+        # @!endgroup
       end
     end
   end


### PR DESCRIPTION
O componente text_area é utilizado como um input de um form, dessa forma é necessário que ele também tenha estados, assim como o text_field, number_field, etc. Isso será importante para fazer o tratamento de erro quando esse componente for utilizado.