### PR TITLE
feat: Adiciona helper no form builder para o componente text area

### DIFF
--- a/app/helpers/ink_components/form_builder.rb
+++ b/app/helpers/ink_components/form_builder.rb
@@ -61,6 +61,11 @@ module InkComponents
       end
     end
 
+    def text_area(attribute, **)
+      state = field_state(attribute)
+      text_area_component(state:, **html_options(attribute), **)
+    end
+
     def error_message(attribute, **)
       state = field_state(attribute)
       helper_text_component(state:, **) { error_messages(attribute) }

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -19,6 +19,7 @@
     <%= f.check_box :paid %>
     <%= f.label :paid, class: "mb-0" %>
   </div>
+  <%= f.text_area :description, cols: 20, rows: 2 %>
 
   <br>
 
@@ -39,6 +40,9 @@
   <%= f.label :email %>
   <%= f.text_field :email %>
 
+  <br><br>
+  <%= f.label :description %>
+  <%= f.text_area :description, cols: 20, rows: 2 %>
   <br><br>
 
   <div class="flex mb-4">

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -7,7 +7,7 @@ class User
   validates :name, length: { minimum: 3 }
   validates :name, format: { with: /\A[a-zA-Z]+\z/, message: "only allows letters" }
 
-  attr_accessor :name, :email, :paid, :type, :color
+  attr_accessor :name, :email, :paid, :type, :color, :description
 
   def initialize(**kwargs)
     super


### PR DESCRIPTION
Neste PR, está sendo adicionado o `method helper` no form builder para utilização do componente `text_area`.