### PR TITLE
fix: Permite que um bloco seja passado ao componente Select

### DIFF
--- a/app/components/ink_components/forms/select/component.html.erb
+++ b/app/components/ink_components/forms/select/component.html.erb
@@ -1,1 +1,1 @@
-<%= select_tag "", options_for_select(options, selected:), prompt:, **attributes %>
+<%= select "", "", (content || options_for_select(choices, options[:selected])), options, attributes %>

--- a/app/components/ink_components/forms/select/component.rb
+++ b/app/components/ink_components/forms/select/component.rb
@@ -66,15 +66,14 @@ module InkComponents
           defaults { { size: :md, state: :default } }
         end
 
-        attr_reader :state, :size, :selected, :prompt, :options, :underline
+        attr_reader :state, :size, :choices, :options, :underline
 
-        def initialize(state: nil, size: nil, selected: nil, prompt: nil, options: {}, underline: false, **extra_attributes)
+        def initialize(state: nil, size: nil, underline: false, choices: {}, options: {}, **extra_attributes)
           @state = state
           @size = size
-          @selected = selected
-          @prompt = prompt
-          @options = options
           @underline = underline
+          @choices = choices
+          @options = options
           super(**extra_attributes)
         end
 

--- a/app/components/ink_components/forms/select/preview.rb
+++ b/app/components/ink_components/forms/select/preview.rb
@@ -9,82 +9,82 @@ module InkComponents
         # @param state select { choices: [default, success, error] }
         # @param disabled toggle
         def playground(state: :default, size: :md, prompt: "Selecione", disabled: false)
-          select_component(state:, size:, prompt:, disabled:, options: DEFAULT_OPTIONS)
+          select_component(state:, size:, disabled:, choices: DEFAULT_OPTIONS, options: { prompt: })
         end
 
         # @!group Html Attributes
         def with_prompt
-          select_component(prompt: "Selecione uma cor", options: DEFAULT_OPTIONS)
+          select_component(choices: DEFAULT_OPTIONS, options: { prompt: "Selecione uma cor" })
         end
 
         def with_selected_option
-          select_component(selected: "Green", options: DEFAULT_OPTIONS)
+          select_component(choices: DEFAULT_OPTIONS, options: { selected: "Blue" })
         end
 
         def with_multiple_options
-          select_component(multiple: true, options: DEFAULT_OPTIONS)
+          select_component(choices: DEFAULT_OPTIONS, multiple: true)
         end
 
         def with_html_attributes
-          select_component(id: "color", name: "color", options: DEFAULT_OPTIONS)
+          select_component(choices: DEFAULT_OPTIONS, id: "color", name: "color")
         end
         # @!endgroup
 
         # @!group States
         def default
-          select_component(state: :default, options: DEFAULT_OPTIONS)
+          select_component(state: :default, choices: DEFAULT_OPTIONS)
         end
 
         def success
-          select_component(state: :success, options: DEFAULT_OPTIONS)
+          select_component(state: :success, choices: DEFAULT_OPTIONS)
         end
 
         def error
-          select_component(state: :error, options: DEFAULT_OPTIONS)
+          select_component(state: :error, choices: DEFAULT_OPTIONS)
         end
 
         def disabled
-          select_component(options: DEFAULT_OPTIONS, disabled: true)
+          select_component(choices: DEFAULT_OPTIONS, disabled: true)
         end
         # @!endgroup
 
         # @!group Sizes
         def small
-          select_component(size: :sm, options: DEFAULT_OPTIONS)
+          select_component(size: :sm, choices: DEFAULT_OPTIONS)
         end
 
         def medium
-          select_component(size: :md, options: DEFAULT_OPTIONS)
+          select_component(size: :md, choices: DEFAULT_OPTIONS)
         end
 
         def large
-          select_component(size: :lg, options: DEFAULT_OPTIONS)
+          select_component(size: :lg, choices: DEFAULT_OPTIONS)
         end
         # @!endgroup
 
         # @!group Underline
         def default
-          select_component(underline: true, options: DEFAULT_OPTIONS)
+          select_component(underline: true, choices: DEFAULT_OPTIONS)
         end
 
         def small_size
-          select_component(underline: true, size: :sm, options: DEFAULT_OPTIONS)
+          select_component(underline: true, size: :sm, choices: DEFAULT_OPTIONS)
         end
 
         def medium_size
-          select_component(underline: true, size: :md, options: DEFAULT_OPTIONS)
+          select_component(underline: true, size: :md, choices: DEFAULT_OPTIONS)
         end
 
         def large_size
-          select_component(underline: true, size: :lg, options: DEFAULT_OPTIONS)
+          select_component(underline: true, size: :lg, choices: DEFAULT_OPTIONS)
         end
 
         def success_state
-          select_component(underline: true, state: :success, options: DEFAULT_OPTIONS)
+          select_component(underline: true, state: :success, choices: DEFAULT_OPTIONS)
         end
 
         def error_state
-          select_component(underline: true, state: :error, options: DEFAULT_OPTIONS)
+          select_component(underline: true, state: :error, choices: DEFAULT_OPTIONS)
         end
         # @!endgroup
       end

--- a/app/helpers/ink_components/form_builder.rb
+++ b/app/helpers/ink_components/form_builder.rb
@@ -28,16 +28,9 @@ module InkComponents
       )
     end
 
-    def select(attribute, choices = nil, select_options = {}, tag_options = {})
-      html_options = html_options(attribute)
-      select_component(
-        state: field_state(attribute),
-        options: choices,
-        selected: html_options[:value],
-        **select_options,
-        **tag_options,
-        **html_options,
-      )
+    def select(attribute, choices = nil, options = {}, tag_options = {}, &)
+      html_options = { id: format_id(attribute), name: format_name(attribute) }.merge(tag_options)
+      select_component(state: field_state(attribute), choices:, options:, **html_options, &)
     end
 
     [

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -22,11 +22,6 @@
 
   <br>
 
-  <%= f.select :color, [], { prompt: "Selecione", include_blank: true } do %>
-    <option value="upfront" selected>À vista</option>
-    <option value="installments">Parcelado</option>
-  <% end %>
-
   <%= f.submit %>
 <% end %>
 
@@ -50,11 +45,6 @@
     <%= f.check_box :paid %>
     <%= f.label :paid, class: "mb-0" %>
   </div>
-
-  <%= f.select :color, [], { prompt: "Selecione", include_blank: true } do %>
-    <option value="upfront" selected>À vista</option>
-    <option value="installments">Parcelado</option>
-  <% end %>
 
   <%= f.submit %>
 <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -22,6 +22,11 @@
 
   <br>
 
+  <%= f.select :color, [], { prompt: "Selecione", include_blank: true } do %>
+    <option value="upfront" selected>À vista</option>
+    <option value="installments">Parcelado</option>
+  <% end %>
+
   <%= f.submit %>
 <% end %>
 
@@ -45,6 +50,11 @@
     <%= f.check_box :paid %>
     <%= f.label :paid, class: "mb-0" %>
   </div>
+
+  <%= f.select :color, [], { prompt: "Selecione", include_blank: true } do %>
+    <option value="upfront" selected>À vista</option>
+    <option value="installments">Parcelado</option>
+  <% end %>
 
   <%= f.submit %>
 <% end %>

--- a/spec/components/ink_components/forms/select_component_spec.rb
+++ b/spec/components/ink_components/forms/select_component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe InkComponents::Forms::Select::Component, type: :component do
 
   it "renders select prompt" do
     choices = { red: "Red", green: "Green", blue: "Blue" }
-    component = render_inline(described_class.new(options: {prompt: "Select some option"}, choices:))
+    component = render_inline(described_class.new(options: { prompt: "Select some option" }, choices:))
 
     expect(component.to_html).to include("Select some option")
   end

--- a/spec/components/ink_components/forms/select_component_spec.rb
+++ b/spec/components/ink_components/forms/select_component_spec.rb
@@ -4,15 +4,15 @@ require "rails_helper"
 
 RSpec.describe InkComponents::Forms::Select::Component, type: :component do
   it "renders select options" do
-    options = { red: "Red", green: "Green", blue: "Blue" }
-    component = render_inline(described_class.new(options:))
+    choices = { red: "Red", green: "Green", blue: "Blue" }
+    component = render_inline(described_class.new(choices:))
 
     expect(component.to_html).to include("red", "green", "blue")
   end
 
   it "renders select prompt" do
-    options = { red: "Red", green: "Green", blue: "Blue" }
-    component = render_inline(described_class.new(prompt: "Select some option", options:))
+    choices = { red: "Red", green: "Green", blue: "Blue" }
+    component = render_inline(described_class.new(options: {prompt: "Select some option"}, choices:))
 
     expect(component.to_html).to include("Select some option")
   end


### PR DESCRIPTION
Atualmente, nosso componente `select` não está configurado para aceitar um bloco. Contudo, a interface helper no Form Builder do Rails suporta o uso de blocos. Portanto, precisamos realizar os ajustes necessários para garantir que nosso helper esteja alinhado com os padrões do Rails.