### PR TITLE
feat: Remove as margens desnecessárias dos componentes button e badge

### DIFF
--- a/app/components/ink_components/badge/component.rb
+++ b/app/components/ink_components/badge/component.rb
@@ -4,7 +4,7 @@ module InkComponents
   module Badge
     class Component < ApplicationComponent
       style do
-        base { "font-medium me-2" }
+        base { "font-medium" }
 
         variants {
           color {
@@ -32,7 +32,7 @@ module InkComponents
             yes { "inline-flex items-center justify-center" }
           }
           dismissible {
-            yes { "inline-flex items-center px-2 py-1 me-2" }
+            yes { "inline-flex items-center px-2 py-1" }
             no { "px-2.5 py-0.5" }
           }
         }

--- a/app/components/ink_components/button/component.rb
+++ b/app/components/ink_components/button/component.rb
@@ -4,7 +4,7 @@ module InkComponents
   module Button
     class Component < ApplicationComponent
       style do
-        base { %w[ focus:ring-4 font-medium text-center me-2 mb-2 focus:outline-none ] }
+        base { %w[ focus:ring-4 font-medium text-center focus:outline-none ] }
 
         variants {
           color {
@@ -101,7 +101,7 @@ module InkComponents
       style :outline do
         base {
           %w[
-            focus:ring-4 font-medium text-center me-2 mb-2 focus:outline-none
+            focus:ring-4 font-medium text-center focus:outline-none
             rounded-lg hover:text-white dark:hover:text-white border bg-transparent dark:bg-transparent
           ]
         }
@@ -135,7 +135,7 @@ module InkComponents
 
       attr_reader :builder, :shape, :color, :size, :href, :disabled
 
-      def initialize(builder: :link_to, shape: :default, color: nil, size: nil, href: "#", **extra_attributes)
+      def initialize(builder: :button_tag, shape: :default, color: nil, size: nil, href: "#", **extra_attributes)
         @builder = builder
         @shape = shape
         @color = color

--- a/app/components/ink_components/button/preview.rb
+++ b/app/components/ink_components/button/preview.rb
@@ -6,7 +6,7 @@ module InkComponents
       # @param content text
       # @param href text
       # @param disabled toggle
-      # @param builder select { choices: [link_to, button_tag, button_to] }
+      # @param builder select { choices: [button_tag, link_to, button_to] }
       # @param color select { choices: [pink, blue, alternative, dark, light, green, red, yellow, purple] }
       # @param size select { choices: [xs, sm, md, lg, xl] }
       # @param shape select { choices: [default, pill, outline] }


### PR DESCRIPTION
Os componentes `button` e `badge` tem classes `me-2` e `mb-2` presentes que adicionam margens extras nesses componentes. Essas margens não deveriam estar presentes. Este PR remove as classes `me-2` e `mb-2` e define o `builder` default do button para `button_tag`.

**Componente Button:**
![image](https://github.com/user-attachments/assets/6b08f3f4-f1d8-405f-9016-e0818ac09837)

**Componente Badge:**
![image](https://github.com/user-attachments/assets/9d6f4f4e-1a69-43ab-bdad-6c3a744f908f)
