### PR TITLE
fix: corrige checkbox quando não recebe content ou helper_text

### DIFF
--- a/app/components/ink_components/forms/checkbox/component.html.erb
+++ b/app/components/ink_components/forms/checkbox/component.html.erb
@@ -1,8 +1,10 @@
 <%= content_tag :div, wrapper_div_attributes do %>
   <%= hidden_field_tag checkbox_name, unchecked_value, id: nil %>
   <%= check_box_tag checkbox_name, checked_value, checked, attributes %>
-  <%= content_tag :div, content_container_div_attributes do %>
-    <%= render(InkComponents::Forms::Label::Component.new(**label_attributes)) { content } %>
-    <%= helper_text %>
+  <% if content.present? || helper_text? %>
+    <%= content_tag :div, content_container_div_attributes do %>
+        <%= render(InkComponents::Forms::Label::Component.new(**label_attributes)) { content } %>
+        <%= helper_text %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/components/ink_components/forms/checkbox/preview.rb
+++ b/app/components/ink_components/forms/checkbox/preview.rb
@@ -87,6 +87,10 @@ module InkComponents
             "Some value"
           end
         end
+
+        def without_helper_text_or_content
+          checkbox_component(id: "product", name: "product[some_value]")
+        end
       end
     end
   end

--- a/spec/components/ink_components/forms/checkbox_component_spec.rb
+++ b/spec/components/ink_components/forms/checkbox_component_spec.rb
@@ -38,4 +38,13 @@ RSpec.describe InkComponents::Forms::Checkbox::Component, type: :component do
       end
     end
   end
+
+  context "when the helper text and content is not provided" do
+    it "doesn't render the helper text and label" do
+      component = render_inline(described_class.new)
+
+      expect(component.css("label")).not_to be_present
+      expect(component.css("p")).not_to be_present
+    end
+  end
 end


### PR DESCRIPTION
### Contexto

O checkbox content adiciona uma div extra ao html mesmo quando não recebe um content ou helper_text. Isso acontece com usos legitimos como:

```erb
<%= form.check_box :name %>
<%= form.label :name %>
```