### PR TITLE
fix: geração do attribute for através do checkbox component

### DIFF
--- a/app/components/ink_components/forms/checkbox/component.html.erb
+++ b/app/components/ink_components/forms/checkbox/component.html.erb
@@ -1,8 +1,10 @@
 <%= content_tag :div, wrapper_div_attributes do %>
   <%= hidden_field_tag checkbox_name, unchecked_value, id: nil %>
   <%= check_box_tag checkbox_name, checked_value, checked, attributes %>
-  <%= content_tag :div, content_container_div_attributes do %>
-    <%= render(InkComponents::Forms::Label::Component.new(**label_attributes)) { content } %>
-    <%= helper_text %>
+  <% if content.present? || helper_text? %>
+    <%= content_tag :div, content_container_div_attributes do %>
+        <%= render(InkComponents::Forms::Label::Component.new(**label_attributes)) { content } %>
+        <%= helper_text %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/components/ink_components/forms/checkbox/component.rb
+++ b/app/components/ink_components/forms/checkbox/component.rb
@@ -101,7 +101,7 @@ module InkComponents
         end
 
         def checkbox_id
-          attributes[:id] || content&.tr(" ", "_")&.downcase
+          attributes[:id] || sanitize_to_id(attributes[:name]) || content&.tr(" ", "_")&.downcase
         end
       end
     end

--- a/app/components/ink_components/forms/checkbox/preview.rb
+++ b/app/components/ink_components/forms/checkbox/preview.rb
@@ -87,6 +87,10 @@ module InkComponents
             "Some value"
           end
         end
+
+        def without_helper_text_or_content
+          checkbox_component(id: "product", name: "product[some_value]")
+        end
       end
     end
   end

--- a/spec/components/ink_components/forms/checkbox_component_spec.rb
+++ b/spec/components/ink_components/forms/checkbox_component_spec.rb
@@ -37,4 +37,14 @@ RSpec.describe InkComponents::Forms::Checkbox::Component, type: :component do
       expect(component.css("p")).not_to be_present
     end
   end
+
+  context "when no id is provided for the component" do
+    context "when content is provided" do
+      it "generates an id for the checkbox and associates it with the label 'for' attribute" do
+        component = render_inline(described_class.new(name: "product[name]")) { "Some label" }
+
+        expect(component.css("label").attr("for").value).to eq("product_name")
+      end
+    end
+  end
 end

--- a/spec/components/ink_components/forms/checkbox_component_spec.rb
+++ b/spec/components/ink_components/forms/checkbox_component_spec.rb
@@ -28,4 +28,13 @@ RSpec.describe InkComponents::Forms::Checkbox::Component, type: :component do
       expect(component.css("p").text.strip).to be_empty
     end
   end
+
+  context "when the helper text and content is not provided" do
+    it "doesn't render the helper text and label" do
+      component = render_inline(described_class.new)
+
+      expect(component.css("label")).not_to be_present
+      expect(component.css("p")).not_to be_present
+    end
+  end
 end


### PR DESCRIPTION
### Contexto

Ao usar o checkbox component sem passar um id o rails irá gerar um id de acordo com o name, devido ao `check_box_tag`. Contudo, ao passar um content para o checkbox será gerado um label com o for incorreto, pois ele usar ou o id do checkbox ou gera um proprio usando o conteudo do label. Esse PR faz o ajuste para que o attribute for use a mesma tecnica do `check_box_tag` para gerar seu attribute `for`

Exemplo:

```erb
<%= checkbox_component(name: "product[name]") { "Nome do produto" } %>
```

Isso resultava em:

```html
<input type="checkbox" name="product[name]" id="product_name">
<label for="nome_do_produto">Nome do produto</label>
```

Com esta correção:

```html
<input type="checkbox" name="product[name]" id="product_name">
<label for="product_name">Nome do produto</label>
```