### PR TITLE
fix: Corrige os previews do componente modal

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ink_components (1.2.0)
+    ink_components (1.2.1)
       inline_svg
       lookbook (= 2.3.2)
       rails (>= 6.1.7.4)

--- a/app/components/ink_components/modal/preview.rb
+++ b/app/components/ink_components/modal/preview.rb
@@ -28,8 +28,8 @@ module InkComponents
           component.with_header(modal_id: "default-modal", title: "Default")
           component.with_body { TEXT_BODY }
           component.with_footer do
-            content_tag :div, class: "w-full flex justify-start items-center p-4" do
-              content_tag(:button, "Fechar", type: "button", class: "focus:ring-4 font-medium text-center focus:outline-none text-white bg-pink-600 hover:bg-pink-800 focus:ring-pink-300 dark:bg-pink-600 dark:hover:bg-pink-700 dark:focus:ring-pink-800 rounded-lg px-5 py-2.5 text-sm", data: { modal_hide: "default-modal" })
+            component.content_tag :div, class: "w-full flex justify-start items-center p-4" do
+              component.content_tag(:button, "Fechar", type: "button", class: "focus:ring-4 font-medium text-center focus:outline-none text-white bg-pink-600 hover:bg-pink-800 focus:ring-pink-300 dark:bg-pink-600 dark:hover:bg-pink-700 dark:focus:ring-pink-800 rounded-lg px-5 py-2.5 text-sm", data: { modal_hide: "default-modal" })
             end
           end
         end
@@ -41,8 +41,8 @@ module InkComponents
           component.with_header(modal_id: "static-modal", title: "Static")
           component.with_body { TEXT_BODY }
           component.with_footer do
-            content_tag :div, class: "w-full flex justify-start items-center p-4" do
-              content_tag(:button, "Fechar", type: "button", class: "focus:ring-4 font-medium text-center focus:outline-none text-white bg-pink-600 hover:bg-pink-800 focus:ring-pink-300 dark:bg-pink-600 dark:hover:bg-pink-700 dark:focus:ring-pink-800 rounded-lg px-5 py-2.5 text-sm", data: { modal_hide: "static-modal" })
+            component.content_tag :div, class: "w-full flex justify-start items-center p-4" do
+              component.content_tag(:button, "Fechar", type: "button", class: "focus:ring-4 font-medium text-center focus:outline-none text-white bg-pink-600 hover:bg-pink-800 focus:ring-pink-300 dark:bg-pink-600 dark:hover:bg-pink-700 dark:focus:ring-pink-800 rounded-lg px-5 py-2.5 text-sm", data: { modal_hide: "static-modal" })
             end
           end
         end
@@ -54,9 +54,9 @@ module InkComponents
           component.with_header(modal_id: "popup-modal", title: "Popup")
           component.with_body { TEXT_BODY }
           component.with_footer do
-            content_tag :div, class: "w-full flex justify-center items-center p-4 gap-2" do
-              content_tag(:button, "Aceitar", type: "button", class: "focus:ring-4 font-medium text-center focus:outline-none text-white bg-red-600 hover:bg-red-800 focus:ring-pink-300 rounded-lg px-5 py-2.5 text-sm", data: { modal_hide: "popup-modal" }) +
-              content_tag(:button, "Declinar", type: "button", class: "focus:ring-4 font-medium text-center focus:outline-none text-white bg-gray-600 hover:bg-gray-800 focus:ring-gray-300 rounded-lg px-5 py-2.5 text-sm", data: { modal_hide: "popup-modal" })
+            component.content_tag :div, class: "w-full flex justify-center items-center p-4 gap-2" do
+              component.content_tag(:button, "Aceitar", type: "button", class: "focus:ring-4 font-medium text-center focus:outline-none text-white bg-red-600 hover:bg-red-800 focus:ring-pink-300 rounded-lg px-5 py-2.5 text-sm", data: { modal_hide: "popup-modal" }) +
+              component.content_tag(:button, "Declinar", type: "button", class: "focus:ring-4 font-medium text-center focus:outline-none text-white bg-gray-600 hover:bg-gray-800 focus:ring-gray-300 rounded-lg px-5 py-2.5 text-sm", data: { modal_hide: "popup-modal" })
             end
           end
         end
@@ -70,8 +70,8 @@ module InkComponents
           component.with_header(modal_id: "small-modal", title: "Small")
           component.with_body { TEXT_BODY }
           component.with_footer do
-            content_tag :div, class: "w-full flex justify-end items-center p-4" do
-              content_tag(:button, "Fechar", type: "button", class: "focus:ring-4 font-medium text-center focus:outline-none text-white bg-pink-600 hover:bg-pink-800 focus:ring-pink-300 dark:bg-pink-600 dark:hover:bg-pink-700 dark:focus:ring-pink-800 rounded-lg px-5 py-2.5 text-sm", data: { modal_hide: "static-modal" })
+            component.content_tag :div, class: "w-full flex justify-end items-center p-4" do
+              component.content_tag(:button, "Fechar", type: "button", class: "focus:ring-4 font-medium text-center focus:outline-none text-white bg-pink-600 hover:bg-pink-800 focus:ring-pink-300 dark:bg-pink-600 dark:hover:bg-pink-700 dark:focus:ring-pink-800 rounded-lg px-5 py-2.5 text-sm", data: { modal_hide: "static-modal" })
             end
           end
         end
@@ -83,8 +83,8 @@ module InkComponents
           component.with_header(modal_id: "medium-modal", title: "Default")
           component.with_body { TEXT_BODY }
           component.with_footer do
-            content_tag :div, class: "w-full flex justify-end items-center p-4" do
-              content_tag(:button, "Fechar", type: "button", class: "focus:ring-4 font-medium text-center focus:outline-none text-white bg-pink-600 hover:bg-pink-800 focus:ring-pink-300 dark:bg-pink-600 dark:hover:bg-pink-700 dark:focus:ring-pink-800 rounded-lg px-5 py-2.5 text-sm", data: { modal_hide: "static-modal" })
+            component.content_tag :div, class: "w-full flex justify-end items-center p-4" do
+              component.content_tag(:button, "Fechar", type: "button", class: "focus:ring-4 font-medium text-center focus:outline-none text-white bg-pink-600 hover:bg-pink-800 focus:ring-pink-300 dark:bg-pink-600 dark:hover:bg-pink-700 dark:focus:ring-pink-800 rounded-lg px-5 py-2.5 text-sm", data: { modal_hide: "static-modal" })
             end
           end
         end
@@ -96,8 +96,8 @@ module InkComponents
           component.with_header(modal_id: "large-modal", title: "Large")
           component.with_body { TEXT_BODY }
           component.with_footer do
-            content_tag :div, class: "w-full flex justify-end items-center p-4" do
-              content_tag(:button, "Fechar", type: "button", class: "focus:ring-4 font-medium text-center focus:outline-none text-white bg-pink-600 hover:bg-pink-800 focus:ring-pink-300 dark:bg-pink-600 dark:hover:bg-pink-700 dark:focus:ring-pink-800 rounded-lg px-5 py-2.5 text-sm", data: { modal_hide: "static-modal" })
+            component.content_tag :div, class: "w-full flex justify-end items-center p-4" do
+              component.content_tag(:button, "Fechar", type: "button", class: "focus:ring-4 font-medium text-center focus:outline-none text-white bg-pink-600 hover:bg-pink-800 focus:ring-pink-300 dark:bg-pink-600 dark:hover:bg-pink-700 dark:focus:ring-pink-800 rounded-lg px-5 py-2.5 text-sm", data: { modal_hide: "static-modal" })
             end
           end
         end
@@ -109,8 +109,8 @@ module InkComponents
           component.with_header(modal_id: "extra-large-modal", title: "Extra large")
           component.with_body { TEXT_BODY }
           component.with_footer do
-            content_tag :div, class: "w-full flex justify-end items-center p-4" do
-              content_tag(:button, "Fechar", type: "button", class: "focus:ring-4 font-medium text-center focus:outline-none text-white bg-pink-600 hover:bg-pink-800 focus:ring-pink-300 dark:bg-pink-600 dark:hover:bg-pink-700 dark:focus:ring-pink-800 rounded-lg px-5 py-2.5 text-sm", data: { modal_hide: "static-modal" })
+            component.content_tag :div, class: "w-full flex justify-end items-center p-4" do
+              component.content_tag(:button, "Fechar", type: "button", class: "focus:ring-4 font-medium text-center focus:outline-none text-white bg-pink-600 hover:bg-pink-800 focus:ring-pink-300 dark:bg-pink-600 dark:hover:bg-pink-700 dark:focus:ring-pink-800 rounded-lg px-5 py-2.5 text-sm", data: { modal_hide: "static-modal" })
             end
           end
         end
@@ -165,15 +165,15 @@ module InkComponents
           component.with_trigger { button("body-modal") }
           component.with_header(modal_id: "body-modal", title: "Modal com Body Personalizado")
           component.with_body do
-            content_tag :div, class: "w-full" do
-              content_tag :div, class: "w-full grid grid-cols-2 gap-2" do
-                content_tag(:div, class: "flex flex-col gap-2") do
-                  content_tag(:label, "Nome", class: "text-sm font-medium text-gray-900 dark:text-white") +
-                  content_tag(:input, nil, type: "text", class: "border-gray-300 rounded-lg px-3 py-2.5 text-sm focus:ring-4 focus:outline-none", placeholder: "João das Neves")
+            component.content_tag :div, class: "w-full" do
+              component.content_tag :div, class: "w-full grid grid-cols-2 gap-2" do
+                component.content_tag(:div, class: "flex flex-col gap-2") do
+                  component.content_tag(:label, "Nome", class: "text-sm font-medium text-gray-900 dark:text-white") +
+                  component.content_tag(:input, nil, type: "text", class: "border-gray-300 rounded-lg px-3 py-2.5 text-sm focus:ring-4 focus:outline-none", placeholder: "João das Neves")
                 end +
-                content_tag(:div, class: "flex flex-col gap-2") do
-                  content_tag(:label, "Idade", class: "text-sm font-medium text-gray-900 dark:text-white") +
-                  content_tag(:input, nil, type: "text", class: "border-gray-300 rounded-lg px-3 py-2.5 text-sm focus:ring-4 focus:outline-none", placeholder: "34")
+                component.content_tag(:div, class: "flex flex-col gap-2") do
+                  component.content_tag(:label, "Idade", class: "text-sm font-medium text-gray-900 dark:text-white") +
+                  component.content_tag(:input, nil, type: "text", class: "border-gray-300 rounded-lg px-3 py-2.5 text-sm focus:ring-4 focus:outline-none", placeholder: "34")
                 end
               end
             end
@@ -195,8 +195,8 @@ module InkComponents
           component.with_header(modal_id: "footer-modal", title: "Modal com Footer Personalizado")
           component.with_body { TEXT_BODY }
           component.with_footer do
-            content_tag :div, class: "w-full flex justify-end items-center p-4" do
-              content_tag(:button, "Salvar", type: "button", class: "focus:ring-4 font-medium text-center focus:outline-none text-white bg-pink-600 hover:bg-pink-800 focus:ring-pink-300 dark:bg-pink-600 dark:hover:bg-pink-700 dark:focus:ring-pink-800 rounded-lg px-5 py-2.5 text-sm", data: { modal_hide: "footer-modal" })
+            component.content_tag :div, class: "w-full flex justify-end items-center p-4" do
+              component.content_tag(:button, "Salvar", type: "button", class: "focus:ring-4 font-medium text-center focus:outline-none text-white bg-pink-600 hover:bg-pink-800 focus:ring-pink-300 dark:bg-pink-600 dark:hover:bg-pink-700 dark:focus:ring-pink-800 rounded-lg px-5 py-2.5 text-sm", data: { modal_hide: "footer-modal" })
             end
           end
         end

--- a/lib/ink_components/version.rb
+++ b/lib/ink_components/version.rb
@@ -1,3 +1,3 @@
 module InkComponents
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end


### PR DESCRIPTION
### Descrição
Este PR corrige o erro que estava acontecendo nos previews do componente `Modal`. O erro era o seguinte:
![image](https://github.com/user-attachments/assets/0c57d488-3e1c-4a20-8f8f-732adc5b4ca1)

O erro acontecia quando um `content_tag` era usado dentro do bloco de algum slot. A correção consistiu em substituir os content_tags por `component_name.content_tag`.

### Mudanças
- Corrige o erro nos previews do componente `Modal`
- Atualiza a versão da gem para `1.2.1`