### PR TITLE
feat: Adiciona novas funcionalidades ao Modal

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ink_components (1.3.1)
+    ink_components (1.2.2)
       inline_svg
       lookbook (= 2.3.2)
       rails (>= 6.1.7.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ink_components (1.2.1)
+    ink_components (1.3.1)
       inline_svg
       lookbook (= 2.3.2)
       rails (>= 6.1.7.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ink_components (1.2.2)
+    ink_components (2.0.0)
       inline_svg
       lookbook (= 2.3.2)
       rails (>= 6.1.7.4)

--- a/app/components/ink_components/modal/component.html.erb
+++ b/app/components/ink_components/modal/component.html.erb
@@ -7,7 +7,7 @@
 				role: 'dialog',
                 class: "hidden overflow-y-auto overflow-x-hidden fixed top-0 left-0 z-50 #{style(placement_classes: :placement)} w-full md:inset-0 h-[calc(100%-1rem)] max-h-full bg-gray-900/50" do %>
 
-	<%= content_tag :div, class: "relative p-4 max-h-full #{style_with_max_width}", style: style_with_width do %>
+	<%= content_tag :div, class: "relative #{padding} max-h-full #{size}" do %>
 		<%= content_tag :div, class: "w-full relative bg-white rounded-lg shadow" do %>
 			<%= header %>
 

--- a/app/components/ink_components/modal/component.html.erb
+++ b/app/components/ink_components/modal/component.html.erb
@@ -1,13 +1,7 @@
 <%= trigger %>
 
-<%= content_tag :div, '', id: modal_id, tabindex: -1, 
-                data: { modal_backdrop: style(type:),
-				        modal_placement: style(placement:)}, 
-                aria: { hidden: 'true' },
-				role: 'dialog',
-                class: "hidden overflow-y-auto overflow-x-hidden fixed top-0 left-0 z-50 #{style(placement_classes: :placement)} w-full md:inset-0 h-[calc(100%-1rem)] max-h-full bg-gray-900/50" do %>
-
-	<%= content_tag :div, class: "relative #{padding} max-h-full #{size}" do %>
+<%= content_tag :div, **wrapper_attributes do %>
+	<%= content_tag :div, **attributes do %>
 		<%= content_tag :div, class: "w-full relative bg-white rounded-lg shadow" do %>
 			<%= header %>
 

--- a/app/components/ink_components/modal/component.rb
+++ b/app/components/ink_components/modal/component.rb
@@ -6,14 +6,7 @@ module InkComponents
       renders_one :body, InkComponents::Modal::Body::Component
       renders_one :footer, InkComponents::Modal::Footer::Component
 
-      style :wrapper do
-        base do
-          %w[
-            hidden overflow-y-auto overflow-x-hidden fixed top-0 left-0 z-50
-            w-full md:inset-0 h-[calc(100%-1rem)] max-h-full bg-gray-900/50
-          ]
-        end
-
+      style do
         variants {
           type {
             dynamic { "dynamic" }
@@ -27,7 +20,18 @@ module InkComponents
             bottom_left { "bottom-left" }
             bottom_right { "bottom-right" }
           }
+        }
+      end
 
+      style :wrapper do
+        base do
+          %w[
+            hidden overflow-y-auto overflow-x-hidden fixed top-0 left-0 z-50
+            w-full md:inset-0 h-[calc(100%-1rem)] max-h-full bg-gray-900/50
+          ]
+        end
+
+        variants {
           placement_classes {
             center { "justify-center items-center " }
             top_left { "justify-start items-start" }
@@ -41,7 +45,7 @@ module InkComponents
       style :modal do
         base do
           %w[
-            relative max-h-full
+            relative max-h-full p-4
           ]
         end
 
@@ -51,11 +55,6 @@ module InkComponents
             md { "max-w-lg" }
             lg { "max-w-4xl" }
             xl { "max-w-7xl" }
-          }
-
-          padding {
-            yes { "p-4" }
-            no {  }
           }
         }
       end
@@ -89,7 +88,7 @@ module InkComponents
       end
 
       def default_attributes
-        { class: style(:modal, max_width:, padding: max_width.blank?) }
+        { class: style(:modal, max_width:) }
       end
     end
   end

--- a/app/components/ink_components/modal/component.rb
+++ b/app/components/ink_components/modal/component.rb
@@ -54,7 +54,7 @@ module InkComponents
       end
 
       def padding
-        max_width.present? ? nil : "p-4"
+     "p-4" if max_width.blank?
       end
     end
   end

--- a/app/components/ink_components/modal/component.rb
+++ b/app/components/ink_components/modal/component.rb
@@ -6,15 +6,15 @@ module InkComponents
       renders_one :body, InkComponents::Modal::Body::Component
       renders_one :footer, InkComponents::Modal::Footer::Component
 
-      style do
-        variants {
-          max_width {
-            sm { "max-w-md" }
-            md { "max-w-lg" }
-            lg { "max-w-4xl" }
-            xl { "max-w-7xl" }
-          }
+      style :wrapper do
+        base do
+          %w[
+            hidden overflow-y-auto overflow-x-hidden fixed top-0 left-0 z-50
+            w-full md:inset-0 h-[calc(100%-1rem)] max-h-full bg-gray-900/50
+          ]
+        end
 
+        variants {
           type {
             dynamic { "dynamic" }
             static { "static" }
@@ -38,23 +38,58 @@ module InkComponents
         }
       end
 
-      attr_reader :modal_id, :max_width, :type, :placement, :responsive_sizes
+      style :modal do
+        base do
+          %w[
+            relative max-h-full
+          ]
+        end
 
-      def initialize(modal_id:, max_width: nil, type: :dynamic, placement: :center, responsive_sizes: nil)
+        variants {
+          max_width {
+            sm { "max-w-md" }
+            md { "max-w-lg" }
+            lg { "max-w-4xl" }
+            xl { "max-w-7xl" }
+          }
+
+          padding {
+            yes { "p-4" }
+            no {  }
+          }
+        }
+      end
+
+      attr_reader :modal_id, :max_width, :type, :placement
+
+      def initialize(modal_id:, max_width: nil, type: :dynamic, placement: :center, **extra_attributes)
         @modal_id = modal_id
         @max_width = max_width
         @type = type
         @placement = placement
-        @responsive_sizes = responsive_sizes
+
+        super(**extra_attributes)
       end
 
       private
-      def size
-        max_width.present? ? style(max_width:) : responsive_sizes
+      def wrapper_attributes
+        {
+          id: modal_id,
+          tabindex: -1,
+          data: {
+            modal_backdrop: style(type:),
+            modal_placement: style(placement:)
+          },
+          aria: {
+            hidden: "hidden"
+          },
+          role: "dialog",
+          class: style(:wrapper, placement_classes: placement)
+        }
       end
 
-      def padding
-     "p-4" if max_width.blank?
+      def default_attributes
+        { class: style(:modal, max_width:, padding: max_width.blank?) }
       end
     end
   end

--- a/app/components/ink_components/modal/component.rb
+++ b/app/components/ink_components/modal/component.rb
@@ -38,23 +38,23 @@ module InkComponents
         }
       end
 
-      attr_reader :modal_id, :max_width, :width, :type, :placement
+      attr_reader :modal_id, :max_width, :type, :placement, :responsive_sizes
 
-      def initialize(modal_id:, max_width: :md, width: nil, type: :dynamic, placement: :center)
+      def initialize(modal_id:, max_width: nil, type: :dynamic, placement: :center, responsive_sizes: nil)
         @modal_id = modal_id
         @max_width = max_width
-        @width = width
         @type = type
         @placement = placement
+        @responsive_sizes = responsive_sizes
       end
 
       private
-      def style_with_max_width
-        width.present? ? nil : style(max_width:)
+      def size
+        max_width.present? ? style(max_width:) : responsive_sizes
       end
 
-      def style_with_width
-        width.present? ? "width: #{width};" : nil
+      def padding
+        max_width.present? ? nil : "p-4"
       end
     end
   end

--- a/app/components/ink_components/modal/header/component.html.erb
+++ b/app/components/ink_components/modal/header/component.html.erb
@@ -6,7 +6,6 @@
     <% end %>
   <% end %>
 
-
   <%= content_tag :button, type: "button", 
                   class: "text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center", 
                   data: { modal_hide: modal_id } do %>

--- a/app/components/ink_components/modal/header/component.html.erb
+++ b/app/components/ink_components/modal/header/component.html.erb
@@ -1,5 +1,11 @@
-<%= content_tag :div, class: "w-full flex items-center justify-between p-4 md:p-5 rounded-t" do %>
-  <%= content_tag :h3, title, class: "text-xl font-semibold text-gray-900 dark:text-white" %>
+<%= content_tag :div, class: "w-full flex items-start justify-between p-4 md:p-5 rounded-t" do %>
+  <%= content_tag :div, class: "flex flex-col gap-1" do %>
+    <%= content_tag :h3, title, class: "text-xl font-semibold text-gray-900 dark:text-white" %>
+    <% if subtitle.present? %>
+      <%= content_tag :span, subtitle, class: "text-gray-500 text-sm font-normal leading-[21px]" %>
+    <% end %>
+  <% end %>
+
 
   <%= content_tag :button, type: "button", 
                   class: "text-gray-400 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm w-8 h-8 ms-auto inline-flex justify-center items-center", 

--- a/app/components/ink_components/modal/header/component.rb
+++ b/app/components/ink_components/modal/header/component.rb
@@ -4,11 +4,12 @@ module InkComponents
   module Modal
     module Header
       class Component < ApplicationComponent
-        attr_reader :modal_id, :title
+        attr_reader :modal_id, :title, :subtitle
 
-        def initialize(modal_id:, title:)
+        def initialize(modal_id:, title:, subtitle: nil)
           @modal_id = modal_id
           @title = title
+          @subtitle = subtitle
         end
       end
     end

--- a/app/components/ink_components/modal/preview.rb
+++ b/app/components/ink_components/modal/preview.rb
@@ -6,16 +6,17 @@ module InkComponents
       TEXT_BODY = "Nossas camisetas são de excelência em algodão brasileiro, ideais para todos os climas. Todas as cores são 100% algodão; exceto cinzas: 88% algodão e 12% poliéster.".freeze
       # @param modal_id text "Id do modal"
       # @param title text "Título do modal"
+      # @param subtitle text "Subtítulo do modal"
       # @param width text "Largura fixa do modal. Especifique a unidade (px, rem, %, etc.)"
       # @param max_width select "Largura máxima do modal" { choices: [ ~, sm, md, lg, xl] }
       # @param body text "Corpo do modal"
       # @param footer text "Rodapé do modal"
       # @param type select "Define o tipo de fechamento do modal" { choices: [[Permite fechar clicando fora do modal, default], [Impede fechamento ao clicar fora, static]] }
       # @param placement select "Posição do modal na tela" { choices: [[Centralizado, center], [Canto superior esquerdo, top_left], [Canto superior direito, top_right], [Canto inferior esquerdo, bottom_left], [Canto inferior direito, bottom_right]] }
-      def playground(modal_id: "playground-modal", type: :default, title: "Título do modal", width: nil, placement: :center, max_width: :md, body: TEXT_BODY, footer: "Rodapé", id: nil)
+      def playground(modal_id: "playground-modal", type: :default, title: "Título do modal", subtitle: "Subtítulo do modal", width: nil, placement: :center, max_width: :md, body: TEXT_BODY, footer: "Rodapé", id: nil)
         modal_component(modal_id:, max_width:, width:, type:, placement:) do |component|
           component.with_trigger { button("playground-modal") }
-          component.with_header(modal_id:, title:)
+          component.with_header(modal_id:, title:, subtitle:)
           component.with_body { body }
           component.with_footer { footer }
         end

--- a/app/components/ink_components/modal/preview.rb
+++ b/app/components/ink_components/modal/preview.rb
@@ -7,14 +7,14 @@ module InkComponents
       # @param modal_id text "Id do modal"
       # @param title text "Título do modal"
       # @param subtitle text "Subtítulo do modal"
-      # @param width text "Largura fixa do modal. Especifique a unidade (px, rem, %, etc.)"
-      # @param max_width select "Largura máxima do modal" { choices: [ ~, sm, md, lg, xl] }
+      # @param responsive_sizes text "Classes Tailwind para tratar tamanho em todas as telas, incluindo dimensões fixas e responsivas (ex: w-[346px] md:w-[678px])"
+      # @param max_width select "Largura máxima do modal. Quando definido, invalida o uso de 'responsive_sizes'." { choices: [ ~, sm, md, lg, xl] }
       # @param body text "Corpo do modal"
       # @param footer text "Rodapé do modal"
       # @param type select "Define o tipo de fechamento do modal" { choices: [[Permite fechar clicando fora do modal, default], [Impede fechamento ao clicar fora, static]] }
       # @param placement select "Posição do modal na tela" { choices: [[Centralizado, center], [Canto superior esquerdo, top_left], [Canto superior direito, top_right], [Canto inferior esquerdo, bottom_left], [Canto inferior direito, bottom_right]] }
-      def playground(modal_id: "playground-modal", type: :default, title: "Título do modal", subtitle: "Subtítulo do modal", width: nil, placement: :center, max_width: :md, body: TEXT_BODY, footer: "Rodapé", id: nil)
-        modal_component(modal_id:, max_width:, width:, type:, placement:) do |component|
+      def playground(modal_id: "playground-modal", type: :default, title: "Título do modal", subtitle: "Subtítulo do modal", responsive_sizes: nil, placement: :center, max_width: :md, body: TEXT_BODY, footer: "Rodapé", id: nil)
+        modal_component(modal_id:, max_width:, type:, placement:, responsive_sizes:) do |component|
           component.with_trigger { button("playground-modal") }
           component.with_header(modal_id:, title:, subtitle:)
           component.with_body { body }

--- a/app/components/ink_components/modal/preview.rb
+++ b/app/components/ink_components/modal/preview.rb
@@ -7,14 +7,14 @@ module InkComponents
       # @param modal_id text "Id do modal"
       # @param title text "Título do modal"
       # @param subtitle text "Subtítulo do modal"
-      # @param responsive_sizes text "Classes Tailwind para tratar tamanho em todas as telas, incluindo dimensões fixas e responsivas (ex: w-[346px] md:w-[678px])"
-      # @param max_width select "Largura máxima do modal. Quando definido, invalida o uso de 'responsive_sizes'." { choices: [ ~, sm, md, lg, xl] }
+      # @param class text "Classes Tailwind para tratar tamanho em todas as telas, incluindo dimensões fixas e responsivas (ex: w-[346px] md:w-[678px])"
+      # @param max_width select "Largura máxima do modal." { choices: [ ~, sm, md, lg, xl] }
       # @param body text "Corpo do modal"
       # @param footer text "Rodapé do modal"
       # @param type select "Define o tipo de fechamento do modal" { choices: [[Permite fechar clicando fora do modal, default], [Impede fechamento ao clicar fora, static]] }
       # @param placement select "Posição do modal na tela" { choices: [[Centralizado, center], [Canto superior esquerdo, top_left], [Canto superior direito, top_right], [Canto inferior esquerdo, bottom_left], [Canto inferior direito, bottom_right]] }
-      def playground(modal_id: "playground-modal", type: :default, title: "Título do modal", subtitle: "Subtítulo do modal", responsive_sizes: nil, placement: :center, max_width: :md, body: TEXT_BODY, footer: "Rodapé", id: nil)
-        modal_component(modal_id:, max_width:, type:, placement:, responsive_sizes:) do |component|
+      def playground(modal_id: "playground-modal", type: :default, title: "Título do modal", subtitle: "Subtítulo do modal", placement: :center, max_width: :md, body: TEXT_BODY, footer: "Rodapé", class: "w-[345px] md:w-[678px]")
+        modal_component(modal_id:, max_width:, type:, placement:, class:) do |component|
           component.with_trigger { button("playground-modal") }
           component.with_header(modal_id:, title:, subtitle:)
           component.with_body { body }

--- a/lib/ink_components/version.rb
+++ b/lib/ink_components/version.rb
@@ -1,3 +1,3 @@
 module InkComponents
-  VERSION = "1.3.1"
+  VERSION = "1.2.2"
 end

--- a/lib/ink_components/version.rb
+++ b/lib/ink_components/version.rb
@@ -1,3 +1,3 @@
 module InkComponents
-  VERSION = "1.2.2"
+  VERSION = "2.0.0"
 end

--- a/lib/ink_components/version.rb
+++ b/lib/ink_components/version.rb
@@ -1,3 +1,3 @@
 module InkComponents
-  VERSION = "1.2.1"
+  VERSION = "1.3.1"
 end

--- a/spec/components/ink_components/modal_component_spec.rb
+++ b/spec/components/ink_components/modal_component_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe InkComponents::Modal::Component, type: :component do
   context "when has a header" do
     it "renders the component" do
-      component = render_inline(described_class.new(modal_id: "default-modal", width: "516px", max_width: :md)) do |modal|
+      component = render_inline(described_class.new(modal_id: "default-modal", max_width: :md)) do |modal|
         modal.with_header(modal_id: "default-modal", title: "Modal Title")
       end
 
@@ -15,7 +15,7 @@ RSpec.describe InkComponents::Modal::Component, type: :component do
 
   context "when has a body" do
     it "renders the component" do
-      component = render_inline(described_class.new(modal_id: "default-modal", width: "516px", max_width: :md)) do |modal|
+      component = render_inline(described_class.new(modal_id: "default-modal", max_width: :md)) do |modal|
         modal.with_body { "Modal Body Content" }
       end
 
@@ -25,7 +25,7 @@ RSpec.describe InkComponents::Modal::Component, type: :component do
 
   context "when has a footer" do
     it "renders the component" do
-      component = render_inline(described_class.new(modal_id: "default-modal", width: "516px", max_width: :md)) do |modal|
+      component = render_inline(described_class.new(modal_id: "default-modal", max_width: :md)) do |modal|
         modal.with_footer { "Modal Footer Content" }
       end
 
@@ -35,7 +35,7 @@ RSpec.describe InkComponents::Modal::Component, type: :component do
 
   context "when has a footer with builder" do
     it "renders the component with a button" do
-      component = render_inline(described_class.new(modal_id: "default-modal", width: "516px", max_width: :md)) do |modal|
+      component = render_inline(described_class.new(modal_id: "default-modal", max_width: :md)) do |modal|
         modal.with_footer do
           "<div class='w-full flex justify-end items-center p-4'>" \
             "<button type='button' class='focus:ring-4 font-medium text-center focus:outline-none text-white bg-pink-600 hover:bg-pink-800 focus:ring-pink-300 dark:bg-pink-600 dark:hover:bg-pink-700 dark:focus:ring-pink-800 rounded-lg px-5 py-2.5 text-sm' " \


### PR DESCRIPTION
**Mudanças**

- Adiciona a opção de incluir um **subtítulo** no modal.
- Refatoração do tratamento de responsividade: Removemos o uso de style inline, permitindo classes Tailwind como: `w-[345px]` e `md:w-[678px]`. Essa alteração foi feita porque a implementação anterior não permitia definir tamanhos específicos para diferentes tamanhos de tela, prejudicando a responsividade do modal.
- Atualiza a versão da gem para 2.0.0.
