### PR TITLE
feat: Adiciona o parâmetro wrapper_attributes

### DIFF
--- a/app/components/ink_components/application_component.rb
+++ b/app/components/ink_components/application_component.rb
@@ -9,14 +9,17 @@ module InkComponents
     attr_reader :attributes
 
     def initialize(**extra_attributes)
-      @attributes = InkComponents::AttributeMerger.new(
-        default_attributes: default_attributes,
-        extra_attributes: extra_attributes
-      ).merge
+      @attributes = mix(default_attributes, extra_attributes)
+    end
 
-      if @attributes[:class].is_a?(String)
-        @attributes[:class] = TailwindMerge::Merger.new.merge(@attributes[:class])
+    def mix(default_attributes, extra_attributes)
+      attributes = AttributeMerger.new(default_attributes:, extra_attributes:).merge
+
+      if attributes[:class].is_a?(String)
+        attributes[:class] = TailwindMerge::Merger.new.merge(attributes[:class])
       end
+
+      attributes
     end
 
     private

--- a/app/components/ink_components/modal/component.rb
+++ b/app/components/ink_components/modal/component.rb
@@ -59,19 +59,27 @@ module InkComponents
         }
       end
 
-      attr_reader :modal_id, :max_width, :type, :placement
+      attr_reader :modal_id, :max_width, :type, :placement, :wrapper_attributes
 
-      def initialize(modal_id:, max_width: nil, type: :dynamic, placement: :center, **extra_attributes)
+      def initialize(
+        modal_id:,
+        max_width: nil,
+        type: :dynamic,
+        placement: :center,
+        wrapper_attributes: {},
+        **extra_attributes
+      )
         @modal_id = modal_id
         @max_width = max_width
         @type = type
         @placement = placement
+        @wrapper_attributes = mix(default_wrapper_attributes, wrapper_attributes)
 
         super(**extra_attributes)
       end
 
       private
-      def wrapper_attributes
+      def default_wrapper_attributes
         {
           id: modal_id,
           tabindex: -1,


### PR DESCRIPTION
Adiciona o parâmetro `wrapper_attributes` para permitir passar atributos para a div mais externa do modal.