### PR TITLE
fix: corrige problema com dropdown em tabelas

### DIFF
--- a/app/components/ink_components/table/component.rb
+++ b/app/components/ink_components/table/component.rb
@@ -8,7 +8,7 @@ module InkComponents
     renders_many :rows, ->(**attrs) { Row::Component.new(hover: @hover, border: @border, **attrs) }
 
     style :wrapper do
-      base { %w[relative overflow-x-auto] }
+      base { %w[overflow-x-auto] }
 
       variants {
         rounded {
@@ -16,7 +16,9 @@ module InkComponents
         }
 
         shadow {
-          yes { %w[shadow-md] }
+          sm { %w[shadow-sm] }
+          md { %w[shadow-md] }
+          lg { %w[shadow-lg] }
         }
       }
     end
@@ -37,7 +39,7 @@ module InkComponents
 
     attr_reader :rounded, :displacement, :shadow, :wrapper_attributes
 
-    def initialize(rounded: true, displacement: nil, hover: false, border: true, shadow: true, wrapper_attributes: {}, **extra_attributes)
+    def initialize(rounded: true, displacement: nil, hover: false, border: true, shadow: :sm, wrapper_attributes: {}, **extra_attributes)
       @rounded = rounded
       @displacement = displacement
       @hover = hover

--- a/app/components/ink_components/table/preview.rb
+++ b/app/components/ink_components/table/preview.rb
@@ -3,13 +3,13 @@
 module InkComponents
   module Table
     class Preview < Lookbook::Preview
-      # @param shadow toggle
+      # @param shadow select { choices: [sm, md, lg] }
       # @param rounded toggle
       # @param border toggle
       # @param hover toggle
       # @param displacement select { choices: [left, right, center] }
       def playground(
-        shadow: true,
+        shadow: :sm,
         rounded: true,
         displacement: :left,
         border: true,


### PR DESCRIPTION
Devido à classe relative aplicada à div wrapper da tabela, não foi possível usar componentes como o dropdown. Além disso, adicionei novas opções de sombras.