### PR TITLE
feat: Implementa o componente Skeleton

### DIFF
--- a/app/components/ink_components/skeleton/component.html.erb
+++ b/app/components/ink_components/skeleton/component.html.erb
@@ -1,0 +1,4 @@
+<%= tag.div(**attributes) do %>
+  <%= content %>
+  <span class="sr-only">Loading...</span>
+<% end %>

--- a/app/components/ink_components/skeleton/component.rb
+++ b/app/components/ink_components/skeleton/component.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module InkComponents
+  module Skeleton
+    class Component < ApplicationComponent
+      style do
+        variants {
+          loading {
+            yes { "animate-pulse" }
+          }
+        }
+
+        defaults { { loading: true } }
+      end
+
+      renders_many :nodes, NodeComponent
+
+      attr_reader :loading
+
+      def initialize(loading: true, **extra_attributes)
+        @loading = loading
+
+        super(**extra_attributes)
+      end
+
+      private
+      def default_attributes
+        { role: "status", class: style(loading:) }
+      end
+    end
+  end
+end

--- a/app/components/ink_components/skeleton/node_component.rb
+++ b/app/components/ink_components/skeleton/node_component.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module InkComponents
+  module Skeleton
+    class NodeComponent < ApplicationComponent
+      style do
+        base do
+          %w[
+            bg-gray-200 dark:bg-gray-700 rounded-full
+          ]
+        end
+      end
+
+      def initialize(**extra_attributes)
+        super(**extra_attributes)
+      end
+
+      def call
+        tag.div(content, **attributes)
+      end
+
+      private
+      def default_attributes
+        {
+          class: style
+        }
+      end
+    end
+  end
+end

--- a/app/components/ink_components/skeleton/preview.rb
+++ b/app/components/ink_components/skeleton/preview.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module InkComponents
+  module Skeleton
+    class Preview < Lookbook::Preview
+      # @param loading toggle
+      def playground(loading: true)
+        render_with_template(template: "previews/ink_components/skeleton/playground", locals: { loading: })
+      end
+
+      # @param loading toggle
+      def image_placeholder(loading: true)
+        render_with_template(template: "previews/ink_components/skeleton/image_placeholder", locals: { loading: })
+      end
+    end
+  end
+end

--- a/app/views/previews/ink_components/skeleton/image_placeholder.html.erb
+++ b/app/views/previews/ink_components/skeleton/image_placeholder.html.erb
@@ -1,0 +1,13 @@
+<%= skeleton_component(loading:, class: "space-y-8 md:space-y-0 md:space-x-8 rtl:space-x-reverse md:flex md:items-center") do |skeleton| %>
+  <div class="flex items-center justify-center w-full h-48 bg-gray-300 rounded-sm sm:w-96 dark:bg-gray-700">
+    <%= icon_component(name: "image", class: "w-10 h-10 text-gray-200 dark:text-gray-600") %>
+  </div>
+  <div class="w-full">
+    <%= skeleton.with_node(class: "h-2.5 w-48 mb-4") %>
+    <%= skeleton.with_node(class: "h-2 max-w-[480px] mb-2.5") %>
+    <%= skeleton.with_node(class: "h-2 mb-2.5") %>
+    <%= skeleton.with_node(class: "h-2 max-w-[440px] mb-2.5") %>
+    <%= skeleton.with_node(class: "h-2 max-w-[460px] mb-2.5") %>
+    <%= skeleton.with_node(class: "h-2 max-w-[360px]") %>
+  </div>
+<% end %>

--- a/app/views/previews/ink_components/skeleton/playground.html.erb
+++ b/app/views/previews/ink_components/skeleton/playground.html.erb
@@ -1,0 +1,8 @@
+<%= skeleton_component(loading:, class: "max-w-sm") do |skeleton| %>
+  <%= skeleton.with_node(class: "h-2.5 w-48 mb-4") %>
+  <%= skeleton.with_node(class: "h-2 max-w-[360px] mb-2.5") %>
+  <%= skeleton.with_node(class: "h-2 mb-2.5") %>
+  <%= skeleton.with_node(class: "h-2 max-w-[330px] mb-2.5") %>
+  <%= skeleton.with_node(class: "h-2 max-w-[300px] mb-2.5") %>
+  <%= skeleton.with_node(class: "h-2 max-w-[360px]") %>
+<% end %>

--- a/spec/components/ink_components/skeleton_component_spec.rb
+++ b/spec/components/ink_components/skeleton_component_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe InkComponents::Skeleton::Component, type: :component do
+  it "renders the component" do
+    component = render_inline(described_class.new) do |component|
+      component.render component.with_node
+    end
+
+    expect(component.css("[role='status']")).to be_present
+    expect(component.css("div").size).to eq(2)
+  end
+end


### PR DESCRIPTION
Implementa o componente [Skeleton](https://flowbite.com/docs/components/skeleton/):

**Playground:**
![image](https://github.com/user-attachments/assets/7c2f848f-df2c-4be0-94c2-77cc09722298)

**Exemplo de skeleton para placeholder de imagem:**
![image](https://github.com/user-attachments/assets/f6354b33-deca-4165-b056-b36026f53b64)
