### PR TITLE
feat: adiciona componente Breadcrumb com suporte a links e icones

### DIFF
--- a/app/components/ink_components/breadcrumb/component.html.erb
+++ b/app/components/ink_components/breadcrumb/component.html.erb
@@ -1,0 +1,3 @@
+<%= content_tag :nav, attributes  do %>
+  <%= list %>
+<% end %>

--- a/app/components/ink_components/breadcrumb/component.rb
+++ b/app/components/ink_components/breadcrumb/component.rb
@@ -53,11 +53,11 @@ module InkComponents
           end
         end
 
+        private
+
         def render?
           !items.empty?
         end
-
-        private
 
         def default_attributes
           { class: style }

--- a/app/components/ink_components/breadcrumb/component.rb
+++ b/app/components/ink_components/breadcrumb/component.rb
@@ -14,7 +14,7 @@ module InkComponents
         defaults { { background: :transparent } }
       end
 
-      renders_one :list, "ListComponent"
+      renders_one :list, InkComponents::Breadcrumb::List::Component
 
       attr_reader :background
 
@@ -26,106 +26,8 @@ module InkComponents
 
       private
 
-      def render?
-        list.present?
-      end
-
       def default_attributes
         { class: style(background:) }
-      end
-
-      class ListComponent < ApplicationComponent
-        renders_many :items, "ItemComponent"
-
-        style do
-          base { %w[inline-flex items-center space-x-1 md:space-x-2 rtl:space-x-reverse] }
-        end
-
-        def initialize(**extra_attributes)
-          super(**extra_attributes)
-        end
-
-        def call
-          content_tag :ol, attributes do
-            items.each do |item|
-              concat item
-            end
-          end
-        end
-
-        private
-
-        def render?
-          !items.empty?
-        end
-
-        def default_attributes
-          { class: style }
-        end
-
-        class ItemComponent < ApplicationComponent
-          style do
-            base { %w[inline-flex items-center] }
-          end
-
-          renders_one :link, "LinkComponent"
-          renders_one :next_page, lambda { InkComponents::Icon::Component.new(name: "chevron-right", type: :outline, class: "rtl:rotate-180 h-6 w-6 text-gray-400 mx-1") }
-
-          def initialize(**extra_attributes)
-            super(**extra_attributes)
-          end
-
-          def call
-            content_tag :li, attributes do
-              content
-            end
-          end
-
-          private
-
-          def render?
-            link.present?
-          end
-
-          def default_attributes
-            { class: style }
-          end
-
-          class LinkComponent < ApplicationComponent
-            renders_one :icon, lambda { |data|
-              InkComponents::Icon::Component.new(**data)
-            }
-
-            style do
-              base { %w[inline-flex items-center text-sm font-medium text-gray-700 hover:text-blue-600 dark:text-gray-400 dark:hover:text-white] }
-            end
-
-            def initialize(href: "#", **extra_attributes)
-              @href = href
-
-              super(**extra_attributes)
-            end
-
-            def call
-              content_tag :a, attributes do
-                content
-              end
-            end
-
-            private
-
-            def render?
-              content.present?
-            end
-
-            def default_attributes
-              {
-                href: @href,
-                class: style
-              }
-            end
-          end
-        end
       end
     end
   end

--- a/app/components/ink_components/breadcrumb/component.rb
+++ b/app/components/ink_components/breadcrumb/component.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+module InkComponents
+  module Breadcrumb
+    class Component < ApplicationComponent
+      style do
+        variants {
+          background {
+            transparent { %w[flex] }
+            solid { %w[ flex px-5 py-3 text-gray-700 border border-gray-200 rounded-lg bg-gray-50 dark:bg-gray-800 dark:border-gray-700 ] }
+          }
+        }
+
+        defaults { { background: :transparent } }
+      end
+
+      renders_one :list, "ListComponent"
+
+      attr_reader :background
+
+      def initialize(background: nil, **extra_attributes)
+        @background = background
+
+        super(**extra_attributes)
+      end
+
+      private
+
+      def render?
+        list.present?
+      end
+
+      def default_attributes
+        { class: style(background:) }
+      end
+
+      class ListComponent < ApplicationComponent
+        renders_many :items, "ItemComponent"
+
+        style do
+          base { %w[inline-flex items-center space-x-1 md:space-x-2 rtl:space-x-reverse] }
+        end
+
+        def initialize(**extra_attributes)
+          super(**extra_attributes)
+        end
+
+        def call
+          content_tag :ol, attributes do
+            items.each do |item|
+              concat item
+            end
+          end
+        end
+
+        def render?
+          !items.empty?
+        end
+
+        private
+
+        def default_attributes
+          { class: style }
+        end
+
+        class ItemComponent < ApplicationComponent
+          style do
+            base { %w[inline-flex items-center] }
+          end
+
+          renders_one :link, "LinkComponent"
+          renders_one :next_page, lambda { InkComponents::Icon::Component.new(name: "chevron-right", type: :outline, class: "rtl:rotate-180 h-6 w-6 text-gray-400 mx-1") }
+
+          def initialize(**extra_attributes)
+            super(**extra_attributes)
+          end
+
+          def call
+            content_tag :li, attributes do
+              content
+            end
+          end
+
+          private
+
+          def render?
+            link.present?
+          end
+
+          def default_attributes
+            { class: style }
+          end
+
+          class LinkComponent < ApplicationComponent
+            renders_one :icon, lambda { |data|
+              InkComponents::Icon::Component.new(**data)
+            }
+
+            style do
+              base { %w[inline-flex items-center text-sm font-medium text-gray-700 hover:text-blue-600 dark:text-gray-400 dark:hover:text-white] }
+            end
+
+            def initialize(href: "#", **extra_attributes)
+              @href = href
+
+              super(**extra_attributes)
+            end
+
+            def call
+              content_tag :a, attributes do
+                content
+              end
+            end
+
+            private
+
+            def render?
+              content.present?
+            end
+
+            def default_attributes
+              {
+                href: @href,
+                class: style
+              }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/ink_components/breadcrumb/list/component.html.erb
+++ b/app/components/ink_components/breadcrumb/list/component.html.erb
@@ -1,0 +1,5 @@
+<%= content_tag :ol, attributes do %>
+  <% items.each do |item| %>
+    <%= item %>
+  <% end %>
+<% end %>

--- a/app/components/ink_components/breadcrumb/list/component.rb
+++ b/app/components/ink_components/breadcrumb/list/component.rb
@@ -14,10 +14,6 @@ module InkComponents
 
         private
 
-        def render?
-          !items.empty?
-        end
-
         def default_attributes
           { class: style }
         end

--- a/app/components/ink_components/breadcrumb/list/component.rb
+++ b/app/components/ink_components/breadcrumb/list/component.rb
@@ -5,7 +5,7 @@ module InkComponents
         renders_many :items, Item::Component
 
         style do
-          base { %w[inline-flex items-center space-x-1 md:space-x-2 rtl:space-x-reverse] }
+          base { %w[inline-flex items-center] }
         end
 
         def initialize(**extra_attributes)

--- a/app/components/ink_components/breadcrumb/list/component.rb
+++ b/app/components/ink_components/breadcrumb/list/component.rb
@@ -1,0 +1,27 @@
+module InkComponents
+  module Breadcrumb
+    module List
+      class Component < ApplicationComponent
+        renders_many :items, Item::Component
+
+        style do
+          base { %w[inline-flex items-center space-x-1 md:space-x-2 rtl:space-x-reverse] }
+        end
+
+        def initialize(**extra_attributes)
+          super(**extra_attributes)
+        end
+
+        private
+
+        def render?
+          !items.empty?
+        end
+
+        def default_attributes
+          { class: style }
+        end
+      end
+    end
+  end
+end

--- a/app/components/ink_components/breadcrumb/list/item/component.html.erb
+++ b/app/components/ink_components/breadcrumb/list/item/component.html.erb
@@ -1,0 +1,7 @@
+
+<%= content_tag :li, attributes do %>
+  <%= icon %>
+  <%= content_tag :a, href: @href, class: "inline-flex items-center text-sm font-medium text-gray-700 hover:text-pink-600 dark:text-gray-400 dark:hover:text-white" do %>
+    <%= content %>
+  <% end %>
+<% end %>

--- a/app/components/ink_components/breadcrumb/list/item/component.html.erb
+++ b/app/components/ink_components/breadcrumb/list/item/component.html.erb
@@ -1,7 +1,10 @@
 
 <%= content_tag :li, attributes do %>
   <%= icon %>
-  <%= content_tag :a, href: @href, class: "inline-flex items-center text-sm font-medium text-gray-700 hover:text-pink-600 dark:text-gray-400 dark:hover:text-white" do %>
-    <%= content %>
+  <% if previous_page? %>
+    <%= previous_page %>
+  <% else %>
+    <%= current_page %>
   <% end %>
+  <%= separator %>
 <% end %>

--- a/app/components/ink_components/breadcrumb/list/item/component.rb
+++ b/app/components/ink_components/breadcrumb/list/item/component.rb
@@ -1,0 +1,35 @@
+module InkComponents
+  module Breadcrumb
+    module List
+      module Item
+        class Component < ApplicationComponent
+          renders_one :icon, lambda { |data|
+            InkComponents::Icon::Component.new(**data)
+          }
+
+          style do
+            base { %w[inline-flex items-center] }
+          end
+
+          renders_one :next_page, lambda { InkComponents::Icon::Component.new(name: "chevron-right", type: :outline, class: "rtl:rotate-180 h-6 w-6 text-gray-400 mx-1") }
+
+          def initialize(href:, **extra_attributes)
+            @href = href
+
+            super(**extra_attributes)
+          end
+
+          private
+
+          def render?
+            content.present?
+          end
+
+          def default_attributes
+            { class: style }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/ink_components/breadcrumb/list/item/component.rb
+++ b/app/components/ink_components/breadcrumb/list/item/component.rb
@@ -13,7 +13,7 @@ module InkComponents
 
           renders_one :next_page, lambda { InkComponents::Icon::Component.new(name: "chevron-right", type: :outline, class: "rtl:rotate-180 h-6 w-6 text-gray-400 mx-1") }
 
-          def initialize(href:, **extra_attributes)
+          def initialize(href: "#", **extra_attributes)
             @href = href
 
             super(**extra_attributes)

--- a/app/components/ink_components/breadcrumb/list/item/component.rb
+++ b/app/components/ink_components/breadcrumb/list/item/component.rb
@@ -21,10 +21,6 @@ module InkComponents
 
           private
 
-          def render?
-            content.present?
-          end
-
           def default_attributes
             { class: style }
           end

--- a/app/components/ink_components/breadcrumb/list/item/component.rb
+++ b/app/components/ink_components/breadcrumb/list/item/component.rb
@@ -6,16 +6,15 @@ module InkComponents
           renders_one :icon, lambda { |data|
             InkComponents::Icon::Component.new(**data)
           }
+          renders_one :separator, lambda { InkComponents::Icon::Component.new(name: "chevron-right", type: :outline, class: "rtl:rotate-180 h-6 w-6 text-gray-400 mx-1") }
+          renders_one :previous_page, "PreviousPageComponent"
+          renders_one :current_page, "CurrentPageComponent"
 
           style do
             base { %w[inline-flex items-center] }
           end
 
-          renders_one :next_page, lambda { InkComponents::Icon::Component.new(name: "chevron-right", type: :outline, class: "rtl:rotate-180 h-6 w-6 text-gray-400 mx-1") }
-
-          def initialize(href: "#", **extra_attributes)
-            @href = href
-
+          def initialize(**extra_attributes)
             super(**extra_attributes)
           end
 
@@ -23,6 +22,52 @@ module InkComponents
 
           def default_attributes
             { class: style }
+          end
+
+          class PreviousPageComponent < ApplicationComponent
+            style do
+              base { %w[inline-flex items-center text-sm font-medium text-gray-700 hover:text-pink-600 dark:text-gray-400 dark:hover:text-white] }
+            end
+
+            attr_reader :href
+
+            def initialize(href: "#", **extra_attributes)
+              @href = href
+
+              super(**extra_attributes)
+            end
+
+            def call
+              link_to href, attributes do
+                content
+              end
+            end
+
+            private
+
+            def default_attributes
+              { class: style }
+            end
+          end
+
+          class CurrentPageComponent < ApplicationComponent
+            style do
+              base { %w[ms-1 text-sm font-medium text-gray-500 md:ms-2 dark:text-gray-400] }
+            end
+
+            def call
+              tag.span(attributes) do
+                content
+              end
+            end
+
+            private
+
+            def default_attributes
+              {
+                class: style
+              }
+            end
           end
         end
       end

--- a/app/components/ink_components/breadcrumb/preview.rb
+++ b/app/components/ink_components/breadcrumb/preview.rb
@@ -5,105 +5,23 @@ module InkComponents
     class Preview < Lookbook::Preview
       # @param list_name text "Nomes das paginas separado po ",""
       # @param background select { choices: [transparent, solid]} "Defina o tipo do plano de fundo"
-      def playground(list_name: "Home,Projects,InkComponents", background: "transparent")
+      def playground(list_name: "Home,Projects,InkComponents", background: :transparent)
         list_name = list_name.split(",")
 
-        breadcrumb_component(background:) do |component|
-          component.with_list do |list|
-            list_name[0..-2].each do |name|
-              list.with_item do |item|
-                safe_join([
-                  item.with_link do
-                    name
-                  end,
-                  item.with_next_page
-                ])
-              end
-            end
-            list_name[-1..-1].each do |name|
-              list.with_item do |item|
-                safe_join([
-                  item.with_link do
-                    name
-                  end
-                ])
-              end
-            end
-          end
-        end
+        render_with_template(template: "previews/ink_components/breadcrumb/playground", locals: { list_name:, background: })
       end
 
       # @!group Exemplos
       def background_transparent
-        breadcrumb_component(background: "transparent") do |component|
-          component.with_list do |list|
-            list.with_item do |item|
-              safe_join([
-                item.with_link do
-                  "Home"
-                end,
-                item.with_next_page
-              ])
-            end
-            list.with_item do |item|
-              safe_join([
-                item.with_link do
-                  "InkComponents"
-                end
-              ])
-            end
-          end
-        end
+        render_with_template(template: "previews/ink_components/breadcrumb/background_transparent")
       end
 
       def background_solid
-        breadcrumb_component(background: "") do |component|
-          component.with_list do |list|
-            list.with_item do |item|
-              safe_join([
-                item.with_link do
-                  "Home"
-                end,
-                item.with_next_page
-              ])
-            end
-            list.with_item do |item|
-              safe_join([
-                item.with_link do
-                  "InkComponents"
-                end
-              ])
-            end
-          end
-        end
+        render_with_template(template: "previews/ink_components/breadcrumb/background_solid")
       end
 
       def items_with_icons
-        breadcrumb_component(background: "") do |component|
-          component.with_list do |list|
-            list.with_item do |item|
-              safe_join([
-                item.with_link do |link|
-                  safe_join([
-                    link.with_icon(name: :home, type: :solid, class: "h-3 w-3 mr-1"),
-                    "Home"
-                  ])
-                end,
-                item.with_next_page
-              ])
-            end
-            list.with_item do |item|
-              safe_join([
-                item.with_link do |link|
-                  safe_join([
-                    link.with_icon(name: :book, type: :solid, class: "h-3 w-3 mr-1"),
-                    "InkComponents"
-                  ])
-                end
-              ])
-            end
-          end
-        end
+        render_with_template(template: "previews/ink_components/breadcrumb/items_with_icons")
       end
       # @!endgroup
     end

--- a/app/components/ink_components/breadcrumb/preview.rb
+++ b/app/components/ink_components/breadcrumb/preview.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module InkComponents
+  module Breadcrumb
+    class Preview < Lookbook::Preview
+      # @param list_name text "Nomes das paginas separado po ",""
+      # @param background select { choices: [transparent, solid]} "Defina o tipo do plano de fundo"
+      def playground(list_name: "Home,Projects,InkComponents", background: "transparent")
+        list_name = list_name.split(",")
+
+        breadcrumb_component(background:) do |component|
+          component.with_list do |list|
+            list_name[0..-2].each do |name|
+              list.with_item do |item|
+                safe_join([
+                  item.with_link do
+                    name
+                  end,
+                  item.with_next_page
+                ])
+              end
+            end
+            list_name[-1..-1].each do |name|
+              list.with_item do |item|
+                safe_join([
+                  item.with_link do
+                    name
+                  end
+                ])
+              end
+            end
+          end
+        end
+      end
+
+      # @!group Exemplos
+      def background_transparent
+        breadcrumb_component(background: "transparent") do |component|
+          component.with_list do |list|
+            list.with_item do |item|
+              safe_join([
+                item.with_link do
+                  "Home"
+                end,
+                item.with_next_page
+              ])
+            end
+            list.with_item do |item|
+              safe_join([
+                item.with_link do
+                  "InkComponents"
+                end
+              ])
+            end
+          end
+        end
+      end
+
+      def background_solid
+        breadcrumb_component(background: "") do |component|
+          component.with_list do |list|
+            list.with_item do |item|
+              safe_join([
+                item.with_link do
+                  "Home"
+                end,
+                item.with_next_page
+              ])
+            end
+            list.with_item do |item|
+              safe_join([
+                item.with_link do
+                  "InkComponents"
+                end
+              ])
+            end
+          end
+        end
+      end
+
+      def items_with_icons
+        breadcrumb_component(background: "") do |component|
+          component.with_list do |list|
+            list.with_item do |item|
+              safe_join([
+                item.with_link do |link|
+                  safe_join([
+                    link.with_icon(name: :home, type: :solid, class: "h-3 w-3 mr-1"),
+                    "Home"
+                  ])
+                end,
+                item.with_next_page
+              ])
+            end
+            list.with_item do |item|
+              safe_join([
+                item.with_link do |link|
+                  safe_join([
+                    link.with_icon(name: :book, type: :solid, class: "h-3 w-3 mr-1"),
+                    "InkComponents"
+                  ])
+                end
+              ])
+            end
+          end
+        end
+      end
+      # @!endgroup
+    end
+  end
+end

--- a/app/views/previews/ink_components/breadcrumb/background_solid.html.erb
+++ b/app/views/previews/ink_components/breadcrumb/background_solid.html.erb
@@ -1,0 +1,11 @@
+<%= breadcrumb_component(background: :solid) do |breadcrumb| %>
+  <%= breadcrumb.with_list do |list| %>
+    <%= list.with_item(href: "#") do |item|%>
+      <%= "Home" %>
+      <%= item.with_next_page %>
+    <% end %>
+    <%= list.with_item(href: "#") do %>
+      <%= "InkComponents" %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/previews/ink_components/breadcrumb/background_solid.html.erb
+++ b/app/views/previews/ink_components/breadcrumb/background_solid.html.erb
@@ -1,11 +1,15 @@
 <%= breadcrumb_component(background: :solid) do |breadcrumb| %>
   <%= breadcrumb.with_list do |list| %>
-    <%= list.with_item(href: "#") do |item|%>
-      <%= "Home" %>
-      <%= item.with_next_page %>
+    <%= list.with_item do |item|%>
+      <% item.with_previous_page(href: "#") do %>
+        <%= "Home" %>
+      <% end %>
+      <%= item.with_separator %>
     <% end %>
-    <%= list.with_item(href: "#") do %>
-      <%= "InkComponents" %>
+    <%= list.with_item do |item| %>
+      <% item.with_current_page do %>
+        <%= "InkComponents" %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/previews/ink_components/breadcrumb/background_transparent.html.erb
+++ b/app/views/previews/ink_components/breadcrumb/background_transparent.html.erb
@@ -1,0 +1,11 @@
+<%= breadcrumb_component(background: :transparent) do |breadcrumb| %>
+  <%= breadcrumb.with_list do |list| %>
+    <%= list.with_item(href: "#") do |item|%>
+      <%= "Home" %>
+      <%= item.with_next_page %>
+    <% end %>
+    <%= list.with_item(href: "#") do %>
+      <%= "InkComponents" %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/previews/ink_components/breadcrumb/background_transparent.html.erb
+++ b/app/views/previews/ink_components/breadcrumb/background_transparent.html.erb
@@ -1,11 +1,15 @@
 <%= breadcrumb_component(background: :transparent) do |breadcrumb| %>
   <%= breadcrumb.with_list do |list| %>
-    <%= list.with_item(href: "#") do |item|%>
-      <%= "Home" %>
-      <%= item.with_next_page %>
+    <%= list.with_item do |item|%>
+      <% item.with_previous_page(href: "#") do %>
+        <%= "Home" %>
+      <% end %>
+      <%= item.with_separator %>
     <% end %>
-    <%= list.with_item(href: "#") do %>
-      <%= "InkComponents" %>
+    <%= list.with_item do |item| %>
+      <% item.with_current_page do %>
+        <%= "InkComponents" %>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/previews/ink_components/breadcrumb/items_with_icons.html.erb
+++ b/app/views/previews/ink_components/breadcrumb/items_with_icons.html.erb
@@ -1,13 +1,17 @@
 <%= breadcrumb_component(background: "") do |breadcrumb| %>
   <% breadcrumb.with_list do |list| %>
-    <% list.with_item(href: "#") do |item| %>
+    <% list.with_item do |item| %>
       <% item.with_icon(name: :home, type: :solid, class: "size-3 mr-1") %>
-      Home
-      <%= item.with_next_page %>
+      <% item.with_previous_page(href: "#") do %>
+        Home
+      <% end %>
+      <%= item.with_separator %>
     <% end %>
-    <% list.with_item(href: "#") do |item| %>
+    <% list.with_item do |item| %>
       <% item.with_icon(name: :book, type: :solid, class: "size-3 mr-1") %>
-      InkComponents
+      <% item.with_current_page do %>
+        InkComponents
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/previews/ink_components/breadcrumb/items_with_icons.html.erb
+++ b/app/views/previews/ink_components/breadcrumb/items_with_icons.html.erb
@@ -1,0 +1,13 @@
+<%= breadcrumb_component(background: "") do |breadcrumb| %>
+  <% breadcrumb.with_list do |list| %>
+    <% list.with_item(href: "#") do |item| %>
+      <% item.with_icon(name: :home, type: :solid, class: "size-3 mr-1") %>
+      Home
+      <%= item.with_next_page %>
+    <% end %>
+    <% list.with_item(href: "#") do |item| %>
+      <% item.with_icon(name: :book, type: :solid, class: "size-3 mr-1") %>
+      InkComponents
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/previews/ink_components/breadcrumb/playground.html.erb
+++ b/app/views/previews/ink_components/breadcrumb/playground.html.erb
@@ -1,14 +1,18 @@
 <%= breadcrumb_component(background:) do |breadcrumb| %>
   <%= breadcrumb.with_list do |list| %>
     <% list_name[0..-2].each do |name| %>
-      <%= list.with_item(href: "#") do |item|%>
-        <%= name %>
-        <%= item.with_next_page %>
+      <%= list.with_item do |item|%>
+        <%= item.with_previous_page(href: "#") do %>
+          <%= name %>
+        <% end %>
+        <%= item.with_separator %>
       <% end %>
     <% end %>
     <% list_name[-1..-1].each do |name| %>
-      <%= list.with_item(href: "#") do %>
-        <%= name %>
+      <%= list.with_item do |item|%>
+        <%= item.with_current_page do %>
+          <%= name %>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/previews/ink_components/breadcrumb/playground.html.erb
+++ b/app/views/previews/ink_components/breadcrumb/playground.html.erb
@@ -1,0 +1,15 @@
+<%= breadcrumb_component(background:) do |breadcrumb| %>
+  <%= breadcrumb.with_list do |list| %>
+    <% list_name[0..-2].each do |name| %>
+      <%= list.with_item(href: "#") do |item|%>
+        <%= name %>
+        <%= item.with_next_page %>
+      <% end %>
+    <% end %>
+    <% list_name[-1..-1].each do |name| %>
+      <%= list.with_item(href: "#") do %>
+        <%= name %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/spec/components/ink_components/breadcrumb_component_spec.rb
+++ b/spec/components/ink_components/breadcrumb_component_spec.rb
@@ -9,8 +9,7 @@ RSpec.describe InkComponents::Breadcrumb::Component, type: :component do
         component = render_inline(described_class.new) do |breadcrumb|
           breadcrumb.with_list do |list|
             list.with_item do |item|
-              safe_join([
-              item.with_link(href: "/home") { "Home" } ])
+              item.with_link(href: "/home") { "Home" }
             end
             list.with_item do |item|
               item.with_link(href: "/products") { "Products" }

--- a/spec/components/ink_components/breadcrumb_component_spec.rb
+++ b/spec/components/ink_components/breadcrumb_component_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe InkComponents::Breadcrumb::Component, type: :component do
           breadcrumb.with_list
         end
 
-        expect(component.to_html).to be_empty
+        expect(component.to_html).not_to include(".ol")
       end
     end
   end

--- a/spec/components/ink_components/breadcrumb_component_spec.rb
+++ b/spec/components/ink_components/breadcrumb_component_spec.rb
@@ -8,12 +8,8 @@ RSpec.describe InkComponents::Breadcrumb::Component, type: :component do
       it "renders the component" do
         component = render_inline(described_class.new) do |breadcrumb|
           breadcrumb.with_list do |list|
-            list.with_item do |item|
-              item.with_link(href: "/home") { "Home" }
-            end
-            list.with_item do |item|
-              item.with_link(href: "/products") { "Products" }
-            end
+            list.with_item(href: "/home") { "Home" }
+            list.with_item(href: "/products") { "Products" }
           end
         end
 
@@ -32,14 +28,6 @@ RSpec.describe InkComponents::Breadcrumb::Component, type: :component do
 
         expect(component.to_html).to be_empty
       end
-    end
-  end
-
-  context "when no list is provided" do
-    it "does not render the component" do
-      component = render_inline(described_class.new)
-
-      expect(component.to_html).to be_empty
     end
   end
 end

--- a/spec/components/ink_components/breadcrumb_component_spec.rb
+++ b/spec/components/ink_components/breadcrumb_component_spec.rb
@@ -8,15 +8,19 @@ RSpec.describe InkComponents::Breadcrumb::Component, type: :component do
       it "renders the component" do
         component = render_inline(described_class.new) do |breadcrumb|
           breadcrumb.with_list do |list|
-            list.with_item(href: "/home") { "Home" }
-            list.with_item(href: "/products") { "Products" }
+            list.with_item do |item|
+              item.with_previous_page(href: "/home") { "Home" }
+              item.with_separator
+            end
+            list.with_item do |item|
+              item.with_current_page { "Products" }
+            end
           end
         end
 
         expect(component.to_html).to include("Home")
         expect(component.to_html).to include("Products")
         expect(component.to_html).to include("href=\"/home\"")
-        expect(component.to_html).to include("href=\"/products\"")
       end
     end
   end

--- a/spec/components/ink_components/breadcrumb_component_spec.rb
+++ b/spec/components/ink_components/breadcrumb_component_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe InkComponents::Breadcrumb::Component, type: :component do
+  context "when the list is provided" do
+    context "when items are provided" do
+      it "renders the component" do
+        component = render_inline(described_class.new) do |breadcrumb|
+          breadcrumb.with_list do |list|
+            list.with_item do |item|
+              safe_join([
+              item.with_link(href: "/home") { "Home" } ])
+            end
+            list.with_item do |item|
+              item.with_link(href: "/products") { "Products" }
+            end
+          end
+        end
+
+        expect(component.to_html).to include("Home")
+        expect(component.to_html).to include("Products")
+        expect(component.to_html).to include("href=\"/home\"")
+        expect(component.to_html).to include("href=\"/products\"")
+      end
+    end
+
+    context "when no items are provided" do
+      it "does not render the list" do
+        component = render_inline(described_class.new) do |breadcrumb|
+          breadcrumb.with_list
+        end
+
+        expect(component.to_html).to be_empty
+      end
+    end
+  end
+
+  context "when no list is provided" do
+    it "does not render the component" do
+      component = render_inline(described_class.new)
+
+      expect(component.to_html).to be_empty
+    end
+  end
+end

--- a/spec/components/ink_components/breadcrumb_component_spec.rb
+++ b/spec/components/ink_components/breadcrumb_component_spec.rb
@@ -19,15 +19,5 @@ RSpec.describe InkComponents::Breadcrumb::Component, type: :component do
         expect(component.to_html).to include("href=\"/products\"")
       end
     end
-
-    context "when no items are provided" do
-      it "does not render the list" do
-        component = render_inline(described_class.new) do |breadcrumb|
-          breadcrumb.with_list
-        end
-
-        expect(component.to_html).not_to include(".ol")
-      end
-    end
   end
 end


### PR DESCRIPTION
Capturas de tela do preview:
Exemplos:
![image](https://github.com/user-attachments/assets/68b7a79a-7298-47c5-8bfd-910ecdf48bf1)

Playground:
![image](https://github.com/user-attachments/assets/f74118ba-5d74-42c9-a072-26028ad08b10)
