### PR TITLE
fix: adiciona validação de renderização em icones

### DIFF
--- a/app/components/ink_components/icon/component.html.erb
+++ b/app/components/ink_components/icon/component.html.erb
@@ -1,1 +1,1 @@
-<%= inline_svg_tag(path, attributes) %>
+<%= inline_svg_tag(path(name, type), attributes) %>

--- a/app/components/ink_components/icon/component.rb
+++ b/app/components/ink_components/icon/component.rb
@@ -14,6 +14,10 @@ module InkComponents
 
       private
 
+      def render?
+        File.exist?(InkComponents::Engine.root.join("app/assets/images/#{path}"))
+      end
+
       def path
         "ink_components/icons/#{type}/#{name}.svg"
       end

--- a/app/components/ink_components/icon/component.rb
+++ b/app/components/ink_components/icon/component.rb
@@ -6,19 +6,24 @@ module InkComponents
       attr_reader :name, :type, :extra_attributes
 
       def initialize(name:, type: :solid, **extra_attributes)
-        @name = name.to_s
-        @type = type.to_s
+        if file_exists?(name, type)
+          @name = name.to_s
+          @type = type.to_s
 
-        super(**extra_attributes)
+          super(**extra_attributes)
+        else
+          raise ArgumentError, "Invalid icon, #{name} with type #{type} does not exist"
+        end
       end
 
       private
 
-      def render?
-        File.exist?(InkComponents::Engine.root.join("app/assets/images/#{path}"))
+      def file_exists?(name, type)
+        file_path = InkComponents::Engine.root.join("app/assets/images/#{path(name, type)}")
+        File.exist?(file_path)
       end
 
-      def path
+      def path(name, type)
         "ink_components/icons/#{type}/#{name}.svg"
       end
     end

--- a/spec/components/ink_components/icon_component_spec.rb
+++ b/spec/components/ink_components/icon_component_spec.rb
@@ -12,10 +12,8 @@ RSpec.describe InkComponents::Icon::Component, type: :component do
   end
 
   context "when the icon does not exist" do
-    it "does not render the icon" do
-      component = render_inline(described_class.new(name: :non_existent, type: :solid))
-
-      expect(component.css("svg")).not_to be_present
+    it "raises an error" do
+      expect { described_class.new(name: :non_existent, type: :solid) }.to raise_error(ArgumentError, "Invalid icon, non_existent with type solid does not exist")
     end
   end
 end

--- a/spec/components/ink_components/icon_component_spec.rb
+++ b/spec/components/ink_components/icon_component_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe InkComponents::Icon::Component, type: :component do
+  context "when the icon exists" do
+    it "renders the icon" do
+      component = render_inline(described_class.new(name: :bell, type: :solid))
+
+      expect(component.css("svg")).to be_present
+    end
+  end
+
+  context "when the icon does not exist" do
+    it "does not render the icon" do
+      component = render_inline(described_class.new(name: :non_existent, type: :solid))
+
+      expect(component.css("svg")).not_to be_present
+    end
+  end
+end


### PR DESCRIPTION
## Contexto

Ao tentar renderizar um icone que não existe o component ainda renderiza um svg vazio o que gerá quebra de layouts. Com isso, iremos gerar um erro para indicar que este icone não existe estimulando o dev a corrigir o error.