### PR TITLE
refactor: Move o tailwind merger para uma constante

### DIFF
--- a/app/components/ink_components/application_component.rb
+++ b/app/components/ink_components/application_component.rb
@@ -5,6 +5,9 @@ require "tailwind_merge"
 module InkComponents
   class ApplicationComponent < ViewComponentContrib::Base
     include ViewComponentContrib::StyleVariants
+    include Helpers
+
+    TAILWIND_MERGER = TailwindMerge::Merger.new.freeze
 
     attr_reader :attributes
 
@@ -13,10 +16,10 @@ module InkComponents
     end
 
     def mix(default_attributes, extra_attributes)
-      attributes = AttributeMerger.new(default_attributes:, extra_attributes:).merge
+      attributes = super(default_attributes, extra_attributes)
 
       if attributes[:class].is_a?(String)
-        attributes[:class] = TailwindMerge::Merger.new.merge(attributes[:class])
+        attributes[:class] = TAILWIND_MERGER.merge(attributes[:class])
       end
 
       attributes

--- a/app/components/ink_components/helpers.rb
+++ b/app/components/ink_components/helpers.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module InkComponents::Helpers
+  private
+
+  def mix(*args)
+    args.each_with_object({}) do |object, result|
+      result.merge!(object) do |_key, old, new|
+        case [ old, new ].freeze
+        in [Array, Array] | [Set, Set]
+          old + new
+        in [Array, Set]
+          old + new.to_a
+        in [Array, String]
+          old + [ new ]
+        in [Hash, Hash]
+          mix(old, new)
+        in [Set, Array]
+          old.to_a + new
+        in [Set, String]
+          old.to_a + [ new ]
+        in [String, Array]
+          [ old ] + new
+        in [String, Set]
+          [ old ] + new.to_a
+        in [String, String]
+          "#{old} #{new}"
+        in [_, Hash]
+          { _: old, **new }
+        in [Hash, _]
+          { **old, _: new }
+        in [_, nil]
+          old
+        else
+          new
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Contexto
O construtor do `ApplicationComponent` cria uma instância do TailwindMerger e AttributeMerger sempre que é invocado. Essas instâncias adicionam overhead na renderização dos componentes.

## Mudanças
Move a inicialização do TailwindMerger para uma constante e move a lógica do AttributeMerger para um helper.

## Benchmark
**Antes:**
![image](https://github.com/user-attachments/assets/f02f5367-43dd-4bb7-9826-3d94df5812b8)

**Depois:**
![image](https://github.com/user-attachments/assets/3adfb7e0-80a6-43ea-88d0-c8f3677e93f4)

<details>
<summary>
Script do benchmark
</summary>

```ruby
require_relative 'config/environment'
require 'benchmark/ips'

class DummyComponent < InkComponents::ApplicationComponent
  def default_attrs
    { class: "bg-white text-black" }
  end
end

Benchmark.ips do |x|
  x.config(time: 5, warmup: 2)

  x.report("basic init") do
    DummyComponent.new
  end

  x.report("init with class") do
    DummyComponent.new(class: "bg-red-500 text-white")
  end

  x.report("init with mixed attrs") do
    DummyComponent.new(id: "main", data: { controller: "test" }, class: "p-2 m-4 text-sm")
  end

  x.compare!
end
```
</details>