### PR TITLE
fix: corrige a exibição da seta no componente popover

### DIFF
--- a/app/components/ink_components/popover/component.rb
+++ b/app/components/ink_components/popover/component.rb
@@ -28,6 +28,7 @@ module InkComponents
           id: @id,
           class: style,
           role: :tooltip,
+          data: { popover: true },
           aria: { hidden: true }
         }
       end

--- a/app/components/ink_components/popover/preview.rb
+++ b/app/components/ink_components/popover/preview.rb
@@ -129,8 +129,8 @@ module InkComponents
               </div>
             </div>".html_safe
           end
+          component.with_arrow
         end
-        component.with_arrow
       end
       # @!endgroup
     end


### PR DESCRIPTION
### Resumo
Este pull request corrige a exibição da seta no componente popover. Foram realizadas pequenas alterações nos arquivos para garantir que o componente seja exibido corretamente.

### Detalhamento
Foi adicionado o `data-popover` por padrão nos atributos do componente, com essa adição a seta funciona conforme o esperado.
Tambem foi alterado o arquivo de preview, pois ele contia um bug. O `component` estava sendo chamado de forma incorreta no preview `popover_company_profile`

Antes:
![image](https://github.com/user-attachments/assets/93d63580-613e-4813-abc5-4a9597cb61eb)

Depois:
![image](https://github.com/user-attachments/assets/b8d93c87-bddf-47fc-adce-bd3fe982592d)
