### PR TITLE
upgrade: atualiza a versão do ink_components para 4.1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ink_components (4.1.0)
+    ink_components (4.1.1)
       inline_svg
       lookbook (= 2.3.2)
       rails (>= 6.1.7.4)

--- a/lib/ink_components/version.rb
+++ b/lib/ink_components/version.rb
@@ -1,3 +1,3 @@
 module InkComponents
-  VERSION = "4.1.0"
+  VERSION = "4.1.1"
 end


### PR DESCRIPTION
Correções dessa atualização:
[fix: corrige a exibição da seta no componente popover](https://github.com/rsv-ink/ink_components/pull/155)