### PR TITLE
refactor: Adiciona color variants para accordion flush

### DIFF
--- a/app/components/ink_components/accordion/component.rb
+++ b/app/components/ink_components/accordion/component.rb
@@ -21,9 +21,36 @@ module InkComponents
         }
       end
 
+      style :flush do
+        base { %w[ bg-white ] }
+
+        variants {
+          active {
+            pink { "text-pink-600" }
+            blue { "text-blue-600" }
+            red { "text-red-600" }
+            green { "text-green-600" }
+            purple { "text-purple-600" }
+            orange { "text-orange-600" }
+            yellow { "text-yellow-600" }
+            gray { "text-gray-900" }
+          }
+          inactive {
+            pink { "text-pink-500" }
+            blue { "text-blue-500" }
+            red { "text-red-500" }
+            green { "text-green-500" }
+            purple { "text-purple-500" }
+            orange { "text-orange-500" }
+            yellow { "text-yellow-500" }
+            gray { "text-gray-500" }
+          }
+        }
+      end
+
       attr_reader :flush, :data_accordion, :color
 
-      def initialize(color: nil, flush: false, data_accordion: :collapse, **extra_attributes)
+      def initialize(color: :gray, flush: false, data_accordion: :collapse, **extra_attributes)
         @flush = flush
         @data_accordion = data_accordion
         @color = color
@@ -35,15 +62,10 @@ module InkComponents
       def default_attributes
         {
           "data-accordion": data_accordion,
-          class: !flush && "border-b border-gray-200"
-        }.tap do |attrs|
-          if flush
-            attrs["data-active-classes"] = "bg-white dark:bg-gray-900 text-gray-900 dark:text-white"
-            attrs["data-inactive-classes"] = "text-gray-500 dark:text-gray-400"
-          else
-            attrs["data-active-classes"] = style(color:) if color
-          end
-        end
+          class: !flush && "border-b border-gray-200",
+          "data-active-classes": flush ? style(:flush, active: color) : style(color:),
+          "data-inactive-classes": flush ? style(:flush, inactive: color) : style(color:)
+        }
       end
     end
   end

--- a/app/components/ink_components/accordion/preview.rb
+++ b/app/components/ink_components/accordion/preview.rb
@@ -158,8 +158,9 @@ module InkComponents
       end
       # @!endgroup
 
-      def flush
-        accordion_component(flush: true) do |component|
+      # @param color select { choices: [gray, pink, green, red, purple, orange, yellow, blue] }
+      def flush(color: :gray)
+        accordion_component(flush: true, color: color) do |component|
           component.with_section(data_target: "section-1", expanded: true) do |section|
             section.with_header { "What is Flowbite?" }
             section.with_body do |body|


### PR DESCRIPTION
Este *pull request* aprimora o componente `Accordion` na biblioteca `ink_components` ao introduzir um novo estilo `flush` com variantes de cor, atualizando a lógica de inicialização para definir uma cor padrão e melhorando o tratamento das classes ativas/inativas para o estilo `flush`. Além disso, modifica o método de *preview* do `flush` para suportar a seleção de cor.

### Melhorias no estilo do componente `Accordion`:
* Adicionado um novo estilo `flush` com variantes de cor para os estados ativo e inativo, com suporte para as cores: `pink`, `blue`, `red`, `green`, `purple`, `orange`, `yellow` e `gray`.
* Atualizado o método `default_attributes` para atribuir dinamicamente `data-active-classes` e `data-inactive-classes` com base no estilo `flush` e na cor selecionada.
* Remove o método `tap` para ajustar o merge dos atrributos vindo do `extra_attributes`

### Melhorias na inicialização e nos *previews*:
* Alterado o método `initialize` para definir `:gray` como cor padrão em vez de `nil`.
* Aprimorado o método de *preview* do `flush` para permitir a seleção de cor através do parâmetro `color`, com valor padrão `:gray`.


![image](https://github.com/user-attachments/assets/3e2c7a4c-7395-4b57-b81d-4ad5dd63e44e)

