### PR TITLE
fix: corrige renderização de icones no preview

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 3.3.4
+ruby 3.3.6
 nodejs 20.11.0

--- a/app/components/ink_components/icon/preview.rb
+++ b/app/components/ink_components/icon/preview.rb
@@ -4,12 +4,12 @@ module InkComponents
       # @!group Types
       # @param name select :icon_names "The icon name"
       def with_solid_type(name: :bell)
-        icon_component(name:, class: "w-6 h-6 fill-gray-500")
+        icon_component(name:, class: "w-6 h-6 fill-gray-500") rescue "Ícone não encontrado para o type: solid"
       end
 
       # @param name select :icon_names "The icon name"
       def with_outline_type(name: :bell)
-        icon_component(name:, type: :outline, class: "w-6 h-6 text-gray-500")
+        icon_component(name:, type: :outline, class: "w-6 h-6 text-gray-500") rescue "Ícone não encontrado para o type: outline"
       end
       # @!endgroup
 

--- a/app/components/ink_components/icon/preview.rb
+++ b/app/components/ink_components/icon/preview.rb
@@ -4,12 +4,12 @@ module InkComponents
       # @!group Types
       # @param name select :icon_names "The icon name"
       def with_solid_type(name: :bell)
-        icon_component(name:, class: "w-6 h-6 fill-gray-500") rescue "Ícone não encontrado para o type: solid"
+        render_with_template(template: "previews/ink_components/icon/solid", locals: { name: })
       end
 
       # @param name select :icon_names "The icon name"
       def with_outline_type(name: :bell)
-        icon_component(name:, type: :outline, class: "w-6 h-6 text-gray-500") rescue "Ícone não encontrado para o type: outline"
+        render_with_template(template: "previews/ink_components/icon/outline", locals: { name: })
       end
       # @!endgroup
 

--- a/app/views/previews/ink_components/icon/outline.html.erb
+++ b/app/views/previews/ink_components/icon/outline.html.erb
@@ -1,1 +1,1 @@
-<%= icon_component(name:, type: :outline, class: "w-6 h-6 text-gray-500") rescue "Ícone não encontrado" %>
+<%= icon_component(name:, type: :outline, class: "w-6 h-6 text-gray-500") rescue "Icon not found" %>

--- a/app/views/previews/ink_components/icon/outline.html.erb
+++ b/app/views/previews/ink_components/icon/outline.html.erb
@@ -1,0 +1,1 @@
+<%= icon_component(name:, type: :outline, class: "w-6 h-6 text-gray-500") rescue "Ícone não encontrado" %>

--- a/app/views/previews/ink_components/icon/solid.html.erb
+++ b/app/views/previews/ink_components/icon/solid.html.erb
@@ -1,1 +1,1 @@
-<%= icon_component(name:, class: "w-6 h-6 fill-gray-500") rescue "Ícone não encontrado" %>
+<%= icon_component(name:, class: "w-6 h-6 fill-gray-500") rescue "Icon not found" %>

--- a/app/views/previews/ink_components/icon/solid.html.erb
+++ b/app/views/previews/ink_components/icon/solid.html.erb
@@ -1,0 +1,1 @@
+<%= icon_component(name:, class: "w-6 h-6 fill-gray-500") rescue "Ícone não encontrado" %>


### PR DESCRIPTION
## Contexto

Quando um icone não é encontrado ele gera um error. Contudo, com isso não conseguimos visualizar todos os icones no modo preview, pois mostramos os dois tipos de icones juntos, mas não quer dizer que vá exister os dois sempre.

![image](https://github.com/user-attachments/assets/feea1d4d-6314-4094-8352-c8d51c4b0ec0)
