### PR TITLE
feat: Adiciona opção para mensagens de erro completas no FormBuilder

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ink_components (4.1.1)
+    ink_components (4.1.2)
       inline_svg
       lookbook (= 2.3.2)
       rails (>= 6.1.7.4)

--- a/app/helpers/ink_components/form_builder.rb
+++ b/app/helpers/ink_components/form_builder.rb
@@ -77,9 +77,9 @@ module InkComponents
       text_area_component(state:, **html_options(attribute, objectify_options(opts)), **sanitize_options(opts))
     end
 
-    def error_message(attribute, **)
+    def error_message(attribute, full: false, **opts)
       state = field_state(attribute)
-      helper_text_component(state:, **) { error_messages(attribute) }
+      helper_text_component(state:, **opts) { error_messages(attribute, full: full) }
     end
 
     def submit(content = nil, **opts, &)
@@ -105,10 +105,14 @@ module InkComponents
       object.errors.include?(attribute) ? :error : :default
     end
 
-    def error_messages(attribute)
+    def error_messages(attribute, full: false)
       return unless object.respond_to?(:errors)
 
-      object.errors[attribute].to_sentence.capitalize.presence&.concat(".")
+      if full
+        object.errors.full_messages_for(attribute).to_sentence.capitalize.presence&.concat(".")
+      else
+        object.errors[attribute].to_sentence.capitalize.presence&.concat(".")
+      end
     end
 
     def html_options(attribute, opts)

--- a/lib/ink_components/version.rb
+++ b/lib/ink_components/version.rb
@@ -1,3 +1,3 @@
 module InkComponents
-  VERSION = "4.1.1"
+  VERSION = "4.1.2"
 end

--- a/spec/helpers/ink_components/form_builder_spec.rb
+++ b/spec/helpers/ink_components/form_builder_spec.rb
@@ -146,4 +146,72 @@ RSpec.describe InkComponents::FormBuilder, type: :helper do
       expect(result).not_to include('enctype="multipart/form-data"')
     end
   end
+
+  describe "#error_message" do
+    context "when full option is true" do
+      it "uses full error messages" do
+        object = User.new(name: "John Doe", email: "invalid")
+        object.errors.add(:email, "is invalid")
+        form_builder = described_class.new(:user, object, helper, {})
+
+        expect(form_builder).to receive(:helper_text_component).with(state: :error) do |**_opts, &block|
+          expect(block.call).to eq("E-mail is invalid.")
+        end
+
+        form_builder.send(:error_message, :email, full: true)
+      end
+
+      it "uses full error messages multiple errors exist" do
+        object = User.new(name: "John Doe", email: "invalid")
+        object.errors.add(:email, "is invalid")
+        object.errors.add(:email, "must be a valid email address")
+        form_builder = described_class.new(:user, object, helper, {})
+
+        expect(form_builder).to receive(:helper_text_component).with(state: :error) do |**_opts, &block|
+          expect(block.call).to eq("E-mail is invalid and e-mail must be a valid email address.")
+        end
+
+        form_builder.send(:error_message, :email, full: true)
+      end
+    end
+
+    context "when full option is false" do
+      it "uses basic error messages when full: false" do
+        object = User.new(name: "John Doe", email: "invalid")
+        object.errors.add(:email, "is invalid")
+        form_builder = described_class.new(:user, object, helper, {})
+
+        expect(form_builder).to receive(:helper_text_component).with(state: :error) do |**_opts, &block|
+          expect(block.call).to eq("Is invalid.")
+        end
+
+        form_builder.send(:error_message, :email, full: false)
+      end
+
+      it "capitalizes and formats basic error messages" do
+        object = User.new(name: "John Doe", email: "invalid")
+        object.errors.add(:email, "is invalid")
+        form_builder = described_class.new(:user, object, helper, {})
+
+        expect(form_builder).to receive(:helper_text_component).with(state: :error) do |**_opts, &block|
+          expect(block.call).to eq("Is invalid.")
+        end
+
+        form_builder.send(:error_message, :email)
+      end
+
+      it "uses error messages multiple errors exist" do
+        object = User.new(name: "John Doe", email: "invalid")
+        object.errors.add(:email, "is invalid")
+        object.errors.add(:email, "must be a valid email address")
+        form_builder = described_class.new(:user, object, helper, {})
+
+        expect(form_builder).to receive(:helper_text_component).with(state: :error) do |**_opts, &block|
+          expect(block.call).to eq("Is invalid and must be a valid email address.")
+        end
+
+        form_builder.send(:error_message, :email)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Objetivo
Cobrir o comportamento de error_message com full: true, garantindo que use mensagens completas de erro.