### PR TITLE
feat: Adiciona ícones de alinhamento horizontal e vertical

### DIFF
--- a/app/assets/images/ink_components/icons/outline/align-bottom.svg
+++ b/app/assets/images/ink_components/icons/outline/align-bottom.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 19h16M9 4h6v11H9z"/>
+</svg>

--- a/app/assets/images/ink_components/icons/outline/align-left.svg
+++ b/app/assets/images/ink_components/icons/outline/align-left.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 6h12M6 10h8M6 14h12M6 18h8"/>
+</svg>

--- a/app/assets/images/ink_components/icons/outline/align-middle.svg
+++ b/app/assets/images/ink_components/icons/outline/align-middle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 12h16M9 7h6v10H9z"/>
+</svg>

--- a/app/assets/images/ink_components/icons/outline/align-right.svg
+++ b/app/assets/images/ink_components/icons/outline/align-right.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 6h12M10 10h8M6 14h12M10 18h8"/>
+</svg>

--- a/app/assets/images/ink_components/icons/outline/align-top.svg
+++ b/app/assets/images/ink_components/icons/outline/align-top.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5h16M9 9h6v11H9z"/>
+</svg>


### PR DESCRIPTION
## Resumo

Adiciona 5 ícones outline complementares ao `align-center.svg` existente, permitindo composição completa de controles de alinhamento horizontal e vertical:

- `align-left.svg`
- `align-right.svg`
- `align-top.svg`
- `align-middle.svg`
- `align-bottom.svg`

## Detalhamento da implementação

Todos os ícones seguem o mesmo padrão visual do `align-center.svg` já existente:

- `viewBox="0 0 24 24"`
- `stroke="currentColor"` (herda cor do contexto via Tailwind/CSS)
- `stroke-width="2"`
- `stroke-linecap="round"` e `stroke-linejoin="round"`
- `fill="none"`

**Horizontais** (alinhamento de texto): 4 linhas horizontais com larguras alternadas, ancoradas no lado correspondente (`align-left` à esquerda, `align-right` à direita).

**Verticais** (alinhamento de caixa): linha horizontal de referência (topo/meio/base) + retângulo da caixa posicionado contra essa linha.

## Motivação

Necessário para os capability components `AlignHorizontalComponent` e `AlignVerticalComponent` do editor de canvas de produtos personalizáveis no `majestic_monolith` (LP-561) — atualmente bloqueados por falta destes ícones. Antes deste PR, esses components recorrem a SVG inline, ferindo a §4.2 da constituição do projeto consumidor.

## Capturas de Tela

Os SVGs podem ser visualizados diretamente nos arquivos. Mesmo estilo do `align-center.svg` já em uso na lib.

## Comandos executados

Nenhum — apenas adição de assets estáticos.

## Riscos conhecidos

Nenhum. São arquivos novos sem mudança em código Ruby/JS. Não há colisão com nomes existentes.