### PR TITLE
upgrade: Atualiza versão do ink_components para 4.2.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ink_components (4.2.2)
+    ink_components (4.2.3)
       inline_svg
       lookbook (= 2.3.2)
       rails (>= 6.1.7.4)
@@ -336,7 +336,7 @@ DEPENDENCIES
   puma
   rspec-rails (= 6.1.4)
   rubocop-rails-omakase (= 1.0.0)
-  sprockets-rails
+  sprockets-rails (= 3.5.2)
   sqlite3 (= 2.1.0)
   tailwind_merge (= 0.13.1)
   view_component (= 3.14.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,7 +336,7 @@ DEPENDENCIES
   puma
   rspec-rails (= 6.1.4)
   rubocop-rails-omakase (= 1.0.0)
-  sprockets-rails (= 3.5.2)
+  sprockets-rails
   sqlite3 (= 2.1.0)
   tailwind_merge (= 0.13.1)
   view_component (= 3.14.0)

--- a/lib/ink_components/version.rb
+++ b/lib/ink_components/version.rb
@@ -1,3 +1,3 @@
 module InkComponents
-  VERSION = "4.2.2"
+  VERSION = "4.2.3"
 end


### PR DESCRIPTION
Atualiza a versão do ink_components referente ao PR [feat: Adiciona ícones de alinhamento horizontal e vertical](https://github.com/rsv-ink/ink_components/pull/166).

> Dependência: aguarda o merge do #166 antes deste.